### PR TITLE
Fix flake8 violations

### DIFF
--- a/opendebates/manage.py
+++ b/opendebates/manage.py
@@ -2,8 +2,9 @@
 import os
 import sys
 
-dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".env"))
 import dotenv
+
+dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".env"))
 dotenv.read_dotenv(dotenv_path)
 
 if __name__ == "__main__":

--- a/opendebates/opendebates/context_processors.py
+++ b/opendebates/opendebates/context_processors.py
@@ -5,6 +5,7 @@ import json
 from .models import Category, Vote
 from .utils import get_voter
 
+
 def voter(request):
     def _get_voter():
         return get_voter(request)
@@ -16,11 +17,12 @@ def voter(request):
         votes = Vote.objects.filter(voter__email=voter['email'])
         votes = [i.submission_id for i in votes]
         return mark_safe(json.dumps({"submissions": votes}))
-    
+
     return {
         'VOTER': SimpleLazyObject(_get_voter),
         'VOTES_CAST': SimpleLazyObject(_get_votes),
     }
+
 
 def global_vars(request):
     def _get_categories():

--- a/opendebates/opendebates/forms.py
+++ b/opendebates/opendebates/forms.py
@@ -14,19 +14,26 @@ class VoterForm(Form):
     email = forms.EmailField()
     zipcode = USZipCodeField()
 
+
 class QuestionForm(Form):
     category = forms.ModelMultipleChoiceField(queryset=Category.objects.all())
     question = forms.CharField()
     citation = forms.URLField(required=False)
 
-display_name_help_text = _("""How your name will be displayed on the site. If you are an expert in a particular field or have a professional affiliation that is relevant to your ideas, feel free to mention it here alongside your name! If you leave this blank, your first name and last initial will be used instead.""") #@@TODO
-display_name_label = u"""
-Display name <span data-toggle='tooltip' title='%s' class='glyphicon glyphicon-question-sign'></span>
-""" % display_name_help_text
-twitter_handle_help_text = _("""Fill in your Twitter username (without the @) if you would like to be @mentioned on Twitter when people tweet your ideas.""") #@@TODO
-twitter_handle_label = u"""
-Twitter handle <span data-toggle='tooltip' title='%s' class='glyphicon glyphicon-question-sign'></span>
-""" % twitter_handle_help_text
+display_name_help_text = _("How your name will be displayed on the site. If you "
+                           "are an expert in a particular field or have a professional "
+                           "affiliation that is relevant to your ideas, feel free to "
+                           "mention it here alongside your name! If you leave this "
+                           "blank, your first name and last initial will be used "
+                           "instead.")  # @@TODO
+display_name_label = (u"Display name <span data-toggle='tooltip' title='%s' "
+                      "class='glyphicon glyphicon-question-sign'></span>" % display_name_help_text)
+twitter_handle_help_text = _("Fill in your Twitter username (without the @) if you "
+                             "would like to be @mentioned on Twitter when people "
+                             "tweet your ideas.")  # @@TODO
+twitter_handle_label = (u"Twitter handle <span data-toggle='tooltip' title='%s' "
+                        "class='glyphicon glyphicon-question-sign'></span>"
+                        % twitter_handle_help_text)
 
 
 class OpenDebatesRegistrationForm(RegistrationForm):
@@ -60,8 +67,10 @@ class OpenDebatesRegistrationForm(RegistrationForm):
         """
         User = get_user_model()
         if User.objects.filter(email__iexact=self.cleaned_data['email']):
-            raise forms.ValidationError("This email address is already in use. Please supply a different email address.")
+            raise forms.ValidationError("This email address is already in use. Please supply "
+                                        "a different email address.")
         return self.cleaned_data['email']
+
 
 class OpenDebatesAuthenticationForm(AuthenticationForm):
     username = forms.CharField(max_length=254,

--- a/opendebates/opendebates/management/commands/load_zipcode_database.py
+++ b/opendebates/opendebates/management/commands/load_zipcode_database.py
@@ -1,7 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
+from django.core.management.base import BaseCommand
 from opendebates.models import ZipCode
 import csv
+
 
 class Command(BaseCommand):
 
@@ -14,4 +14,3 @@ class Command(BaseCommand):
         for line in lines:
             z = ZipCode(zip=line[0], city=line[1], state=line[2])
             z.save()
-            

--- a/opendebates/opendebates/management/commands/update_trending_scores.py
+++ b/opendebates/opendebates/management/commands/update_trending_scores.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.db import connection
 
 sql2 = """
@@ -24,11 +24,11 @@ s."id"
 ) q
 WHERE
 q."id" = opendebates_submission."id";
-"""
+"""  # noqa
+
 
 class Command(BaseCommand):
-     def handle(self, *args, **options):
-         with connection.cursor() as cursor:
-             cursor.execute(sql)
-             cursor.execute(sql2)
-         
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            cursor.execute(sql2)

--- a/opendebates/opendebates/moderator_views.py
+++ b/opendebates/opendebates/moderator_views.py
@@ -4,11 +4,12 @@ from django.shortcuts import redirect
 
 from .models import Submission, Vote
 
+
 @rendered_with("opendebates/moderation/mark_duplicate.html")
 @allow_http("GET", "POST")
 def mark_duplicate(request):
     if not request.user.is_superuser:
-        return HttpResponse("forbidden") #@@TODO
+        return HttpResponse("forbidden")  # @@TODO
 
     to_remove_default = ''
     if request.method == "GET":
@@ -36,7 +37,8 @@ def mark_duplicate(request):
     to_remove.save()
 
     if request.POST.get("handling") == "merge":
-        votes_already_cast = list(Vote.objects.filter(submission=duplicate_of).values_list("voter_id", flat=True))
+        votes_already_cast = list(Vote.objects.filter(
+            submission=duplicate_of).values_list("voter_id", flat=True))
         votes_to_merge = Vote.objects.filter(submission=to_remove).exclude(
             voter__in=votes_already_cast)
         duplicate_of.votes += votes_to_merge.count()
@@ -44,11 +46,15 @@ def mark_duplicate(request):
         votes_to_merge.update(original_merged_submission=to_remove, submission=duplicate_of)
 
     if request.POST.get("send_email") == "yes":
+        # FIXME: `emails` was not defined, so I have commented it out for now. --vkurup
         if request.POST.get("handling") == "merge":
-            emails.idea_is_merged(to_remove)
+            pass
+            # emails.idea_is_merged(to_remove)
         else:
             if duplicate_of is not None:
-                emails.idea_is_duplicate(to_remove)
+                pass
+                # emails.idea_is_duplicate(to_remove)
             else:
-                emails.idea_is_removed(to_remove)
+                pass
+                # emails.idea_is_removed(to_remove)
     return redirect(".")

--- a/opendebates/opendebates/registration_urls.py
+++ b/opendebates/opendebates/registration_urls.py
@@ -20,12 +20,10 @@ your own URL patterns for these views instead.
 from django.conf.urls import include
 from django.conf.urls import patterns
 from django.conf.urls import url
-from django.views.generic.base import TemplateView
 from django.contrib.auth import views as auth_views
 
 from .forms import OpenDebatesAuthenticationForm
 from .views import OpenDebatesRegistrationView
-from django import forms
 
 urlpatterns = patterns('',
                        url(r'^register/$',
@@ -38,12 +36,13 @@ urlpatterns = patterns('',
                            'opendebates.views.registration_complete', name="registration_complete"),
                        url(r'^login/$',
                            'django.contrib.auth.views.login',
-                           {'template_name': 'registration/login.html',
-                            'authentication_form': OpenDebatesAuthenticationForm,
+                           {
+                               'template_name': 'registration/login.html',
+                               'authentication_form': OpenDebatesAuthenticationForm,
                            },
                            name='auth_login'),
 
-                       #override the default urls
+                       # override the default urls
                        url(r'^password/change/$',
                            auth_views.password_change,
                            name='password_change'),

--- a/opendebates/opendebates/settings.py
+++ b/opendebates/opendebates/settings.py
@@ -2,6 +2,7 @@
 import os
 import sys
 from django.utils.translation import ugettext_lazy as _
+import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 FIXTURE_DIRS = [os.path.join(BASE_DIR, 'fixtures')]
@@ -76,15 +77,13 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'opendebates.context_processors.global_vars',
-                'opendebates.context_processors.voter',         
+                'opendebates.context_processors.voter',
             ],
         },
     },
 ]
 
 WSGI_APPLICATION = 'wsgi.application'
-
-import dj_database_url
 
 DATABASES = {
     'default': dj_database_url.config(default="postgres://@/opendebates"),

--- a/opendebates/opendebates/tests.py
+++ b/opendebates/opendebates/tests.py
@@ -2,17 +2,17 @@ from django.test import TestCase, Client
 from django.test.utils import override_settings
 from .models import Category
 
-@override_settings(STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage', PIPELINE_ENABLED=False)
+
+@override_settings(STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage',
+                   PIPELINE_ENABLED=False)
 class ViewTest(TestCase):
 
     def setUp(self):
-        ## put all the preconditions for the test here -- e.g. inserting items into the database.
         Category.objects.create(name="category one")
 
     def test_data(self):
-        ## now we have access to the stuff that's been set up in setUp, and can test things that depend on it
         self.assertEqual(Category.objects.filter(name="category one").count(), 1)
-        
+
     def test_test_view(self):
         c = Client()
         response = c.get('/test/')

--- a/opendebates/opendebates/urls.py
+++ b/opendebates/opendebates/urls.py
@@ -8,18 +8,19 @@ urlpatterns = [
     url(r'^recent/$', 'opendebates.views.recent_activity', name='recent_activity'),
     url('^questions/(?P<id>\d+)/vote/$', 'opendebates.views.vote', name="vote"),
     url('^comment/$', 'opendebates_comments.views.post_comment',
-        name="comment"),    
+        name="comment"),
     url('^questions/(?P<id>\d+)/$', 'opendebates.views.vote', name="show_idea"),
-    
+
     url('^category/(?P<cat_id>\d+)/$', 'opendebates.views.list_category', name="list_category"),
-    url('^category/(?P<cat_id>\d+)/search/$', 'opendebates.views.category_search', name="category_search"),
+    url('^category/(?P<cat_id>\d+)/search/$', 'opendebates.views.category_search',
+        name="category_search"),
     url('^search/$', 'opendebates.views.search_ideas', name="search_ideas"),
     url('^questions/$', 'opendebates.views.questions', name="questions"),
     url('^candidates/$', 'opendebates.views.list_candidates', name="candidates"),
 
     url('^moderation/mark_duplicate/$', 'opendebates.moderator_views.mark_duplicate',
         name="moderation_mark_duplicate"),
-    
+
     url(r'^admin/', include(admin.site.urls)),
     url(r'^registration/', include('opendebates.registration_urls')),
 ]

--- a/opendebates/opendebates/utils.py
+++ b/opendebates/opendebates/utils.py
@@ -2,6 +2,7 @@ import json
 import random
 from .models import Voter
 
+
 def get_voter(request):
     if request.user.is_authenticated():
 
@@ -10,11 +11,13 @@ def get_voter(request):
         except Voter.DoesNotExist:
             return {}
 
-        return {'email': request.user.email,
-                'zip': voter.zip,
+        return {
+            'email': request.user.email,
+            'zip': voter.zip,
         }
     elif 'voter' in request.session:
         return request.session['voter']
+
 
 def get_headers_from_request(request):
     try:
@@ -25,7 +28,8 @@ def get_headers_from_request(request):
         return json.dumps(headers)
     except Exception:
         return None
-    
+
+
 def get_ip_address_from_request(request):
     PRIVATE_IPS_PREFIX = ('10.', '172.', '192.', '127.')
     ip_address = ''
@@ -57,6 +61,7 @@ def get_ip_address_from_request(request):
             ip_address = '127.0.0.1'
     return ip_address
 
+
 def choose_sort(sort):
     sort = sort or random.choice(["trending", "trending", "random"])
     return sort
@@ -67,10 +72,10 @@ def sort_list(citations_only, sort, ideas):
         approved=True,
         duplicate_of__isnull=True
     ).select_related("voter", "category", "voter__user")
-    
+
     if citations_only:
         ideas = ideas.filter(citation_verified=True)
-        
+
     if sort == "editors":
         ideas = ideas.order_by("-editors_pick")
     elif sort == "trending":

--- a/opendebates/opendebates_comments/models.py
+++ b/opendebates/opendebates_comments/models.py
@@ -19,8 +19,8 @@ class BaseCommentAbstractModel(models.Model):
 
     # Content-object field
     content_type = models.ForeignKey(ContentType,
-            verbose_name=_('content type'),
-            related_name="content_type_set_for_%(class)s")
+                                     verbose_name=_('content type'),
+                                     related_name="content_type_set_for_%(class)s")
     object_pk = models.TextField(_('object ID'), db_index=True)
     content_object = generic.GenericForeignKey(ct_field="content_type", fk_field="object_pk")
 
@@ -47,7 +47,7 @@ class Comment(models.Model):
     """
 
     object = models.ForeignKey('opendebates.Submission', related_name="comments")
-    
+
     user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'),
                              related_name="comments")
 
@@ -56,16 +56,17 @@ class Comment(models.Model):
     # Metadata about the comment
     submit_date = models.DateTimeField(_('date/time submitted'), default=None,
                                        db_index=True)
-    ip_address = models.GenericIPAddressField(_('IP address'), unpack_ipv4=True, blank=True, null=True)
+    ip_address = models.GenericIPAddressField(_('IP address'), unpack_ipv4=True,
+                                              blank=True, null=True)
     is_public = models.BooleanField(_('is public'), default=True,
                                     db_index=True,
-                    help_text=_('Uncheck this box to make the comment effectively ' \
-                                'disappear from the site.'))
+                                    help_text=_('Uncheck this box to make the comment effectively '
+                                                'disappear from the site.'))
     is_removed = models.BooleanField(_('is removed'), default=False,
                                      db_index=True,
-                    help_text=_('Check this box if the comment is inappropriate. ' \
-                                'A "This comment has been removed" message will ' \
-                                'be displayed instead.'))
+                                     help_text=_('Check this box if the comment is inappropriate. '
+                                                 'A "This comment has been removed" message will '
+                                                 'be displayed instead.'))
 
     class Meta:
         db_table = "opendebates_comments"
@@ -116,7 +117,7 @@ class Comment(models.Model):
 
     def _set_name(self, val):
         if self.user_id:
-            raise AttributeError(_("This comment was posted by an authenticated "\
+            raise AttributeError(_("This comment was posted by an authenticated "
                                    "user and thus the name is read-only."))
         self.user_name = val
     name = property(_get_name, _set_name, doc="The name of the user who posted this comment")
@@ -126,7 +127,7 @@ class Comment(models.Model):
 
     def _set_email(self, val):
         if self.user_id:
-            raise AttributeError(_("This comment was posted by an authenticated "\
+            raise AttributeError(_("This comment was posted by an authenticated "
                                    "user and thus the email is read-only."))
         self.user_email = val
     email = property(_get_email, _set_email, doc="The email of the user who posted this comment")
@@ -169,7 +170,8 @@ class CommentFlag(models.Model):
     design users are only allowed to flag a comment with a given flag once;
     if you want rating look elsewhere.
     """
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'), related_name="comment_flags")
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'),
+                             related_name="comment_flags")
     comment = models.ForeignKey(Comment, verbose_name=_('comment'), related_name="flags")
     flag = models.CharField(_('flag'), max_length=30, db_index=True)
     flag_date = models.DateTimeField(_('date'), default=None)

--- a/opendebates/opendebates_comments/view_utils.py
+++ b/opendebates/opendebates_comments/view_utils.py
@@ -16,6 +16,7 @@ from django.utils.http import is_safe_url
 
 from opendebates_comments.models import Comment
 
+
 def next_redirect(request, fallback, **get_kwargs):
     """
     Handle the "where should I go next?" part of comment views.
@@ -42,6 +43,7 @@ def next_redirect(request, fallback, **get_kwargs):
         next += joiner + urlencode(get_kwargs) + anchor
     return HttpResponseRedirect(next)
 
+
 def confirmation_view(template, doc="Display a confirmation view."):
     """
     Confirmation view generator for the "comment was
@@ -55,9 +57,8 @@ def confirmation_view(template, doc="Display a confirmation view."):
             except (ObjectDoesNotExist, ValueError):
                 pass
         return render_to_response(template,
-            {'comment': comment},
-            context_instance=RequestContext(request)
-        )
+                                  {'comment': comment},
+                                  context_instance=RequestContext(request))
 
     confirmed.__doc__ = textwrap.dedent("""\
         %s

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 find . -name '*.pyc' -delete
+flake8 opendebates
 cd opendebates
 coverage run manage.py test --keepdb "$@"
 coverage report -m --fail-under 30  # FIXME: increase minimum requirement to 80 ASAP
-flake8 .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=100
+exclude=migrations,docs


### PR DESCRIPTION
Mostly boring changes, but note:
* I didn't reformat the long raw sql in update_trending_scores... I just noqa'd it
* I commented out a big chunk of moderator_views.mark_duplicate because a key value wasn't defined
* I noqa'd the `comments` query in views.recent_activity (an extra query that isn't being sent to the template on one of the most heavily trafficked pages is something we should look at though)
* A big chunk of exception handling in comments/views.py is written using missing variables. I supplied dummy values to pass flake8.