### PR TITLE
Add tests for registration functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 script:
   - python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
   - coverage run manage.py test
-  - coverage report -m --fail-under 30
+  - coverage report -m --fail-under 40
   - flake8 .
 
 notifications:

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -127,9 +127,6 @@ PIPELINE_COMPILERS = (
     'pipeline.compilers.less.LessCompiler',
 )
 
-if 'test' in sys.argv:
-    PIPELINE_COMPILERS = ()
-
 if DEBUG:
     PIPELINE_CSS_COMPRESSOR = None
     PIPELINE_JS_COMPRESSOR = None
@@ -200,3 +197,7 @@ BOWER_INSTALLED_APPS = (
 SITE_ID = 1
 SITE_DOMAIN = os.environ.get("SITE_DOMAIN", "127.0.0.1:8000")
 SITE_DOMAIN_WITH_PROTOCOL = os.environ.get("SITE_PROTOCOL", "http://") + SITE_DOMAIN
+
+if 'test' in sys.argv:
+    PIPELINE_COMPILERS = ()
+    PIPELINE_ENABLED = False

--- a/opendebates/tests/factories.py
+++ b/opendebates/tests/factories.py
@@ -1,0 +1,23 @@
+from django.contrib.auth import get_user_model
+
+import factory
+
+
+class UserFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+
+    username = factory.Sequence(lambda n: "user%d" % n)
+    email = factory.LazyAttribute(lambda o: '%s@example.org' % o.username)
+    password = factory.PostGenerationMethodCall('set_password', 'password')
+
+    is_staff = False
+    is_active = True
+
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            for group in extracted:
+                self.groups.add(group)

--- a/opendebates/tests/test_preexisting.py
+++ b/opendebates/tests/test_preexisting.py
@@ -1,6 +1,6 @@
 from django.test import TestCase, Client
 from django.test.utils import override_settings
-from .models import Category
+from ..models import Category
 
 
 @override_settings(STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage',

--- a/opendebates/tests/test_registration.py
+++ b/opendebates/tests/test_registration.py
@@ -1,0 +1,113 @@
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from .factories import UserFactory
+
+
+class RegisterTest(TestCase):
+
+    def setUp(self):
+        self.url = reverse('registration_register')
+        self.data = {
+            'username': 'gwash',
+            'password1': 'secretpassword',
+            'password2': 'secretpassword',
+            'first_name': 'George',
+            'last_name': 'Washington',
+            'email': 'gwash@example.com',
+            'zip': '12345',
+        }
+
+    def test_registration_get(self):
+        "GET the form successfully."
+        with self.assertTemplateUsed('registration/registration_form.html'):
+            rsp = self.client.get(self.url)
+        self.assertEqual(200, rsp.status_code)
+
+    def test_post_success(self):
+        "POST the form with all required values."
+        home_url = reverse('list_ideas')
+        rsp = self.client.post(self.url, data=self.data, follow=True)
+        self.assertRedirects(rsp, home_url)
+        new_user = get_user_model().objects.first()
+        self.assertEqual(new_user.first_name, self.data['first_name'])
+
+    def test_post_missing_variable(self):
+        "POST with a missing required value."
+        # delete each required key and POST
+        for key in self.data:
+            data = self.data.copy()
+            del data[key]
+            rsp = self.client.post(self.url)
+            self.assertEqual(200, rsp.status_code)
+            form = rsp.context['form']
+            self.assertIn(key, form.errors)
+            self.assertIn('field is required', str(form.errors))
+
+    def test_email_must_be_unique(self):
+        # case insensitive
+        UserFactory(email=self.data['email'].upper())
+        rsp = self.client.post(self.url, data=self.data, follow=True)
+        form = rsp.context['form']
+        self.assertEqual(200, rsp.status_code)
+        self.assertIn('email', form.errors)
+        self.assertIn('already in use', str(form.errors))
+
+    def test_twitter_handle_gets_cleaned(self):
+        "Various forms of twitter_handle entries are cleaned to canonical form."
+        data = {}
+        for twitter_handle in [
+                '@twitter',
+                'twitter',
+                'https://twitter.com/twitter',
+                'http://twitter.com/twitter',
+                'twitter.com/twitter',
+        ]:
+            data['twitter_handle'] = twitter_handle
+            rsp = self.client.post(self.url, data=data)
+            form = rsp.context['form']
+            self.assertEqual('twitter', form.cleaned_data['twitter_handle'])
+
+
+class LoginLogoutTest(TestCase):
+
+    def setUp(self):
+        self.username = 'gwash'
+        self.email = 'gwash@example.com'
+        self.password = 'secretpassword'
+        UserFactory(username=self.username,
+                    email=self.email,
+                    password=self.password)
+        self.login_url = reverse('auth_login')
+        self.home_url = reverse('list_ideas')
+
+    def test_login_with_username(self):
+        rsp = self.client.post(
+            self.login_url,
+            data={'username': self.username, 'password': self.password, 'next': '/'}
+        )
+        self.assertRedirects(rsp, self.home_url)
+
+    def test_login_with_email(self):
+        rsp = self.client.post(
+            self.login_url,
+            data={'username': self.email, 'password': self.password, 'next': '/'}
+        )
+        self.assertRedirects(rsp, self.home_url)
+
+    def test_failed_login(self):
+        rsp = self.client.post(
+            self.login_url,
+            data={'username': self.username, 'password': self.password + 'bad', 'next': '/'}
+        )
+        self.assertEqual(200, rsp.status_code)
+        form = rsp.context['form']
+        self.assertIn('enter a correct username and password', str(form.errors))
+
+    def test_logout(self):
+        self.assertTrue(self.client.login(username=self.username, password=self.password))
+        logout_url = reverse('auth_logout')
+        with self.assertTemplateUsed('registration/logout.html'):
+            rsp = self.client.get(logout_url)
+        self.assertIn('Log in', rsp.content)

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -302,26 +302,26 @@ class OpenDebatesRegistrationView(RegistrationView):
 
     form_class = OpenDebatesRegistrationForm
 
-    def register(self, request, **cleaned_data):
-        new_user = RegistrationView.register(self, request, **cleaned_data)
-        new_user.first_name = cleaned_data['first_name']
-        new_user.last_name = cleaned_data['last_name']
+    def register(self, request, form):
+        new_user = RegistrationView.register(self, request, form)
+        new_user.first_name = form.cleaned_data['first_name']
+        new_user.last_name = form.cleaned_data['last_name']
         new_user.save()
 
         try:
-            voter = Voter.objects.get(email=cleaned_data['email'])
+            voter = Voter.objects.get(email=form.cleaned_data['email'])
         except Voter.DoesNotExist:
-            voter = Voter(email=cleaned_data['email'])
+            voter = Voter(email=form.cleaned_data['email'])
             if 'opendebates.source' in request.COOKIES:
                 voter.source = request.COOKIES['opendebates.source']
 
-        voter.zip = cleaned_data['zip']
+        voter.zip = form.cleaned_data['zip']
         try:
-            voter.state = ZipCode.objects.get(zip=cleaned_data['zip']).state
+            voter.state = ZipCode.objects.get(zip=form.cleaned_data['zip']).state
         except Exception:
             pass
-        voter.display_name = cleaned_data.get('display_name')
-        voter.twitter_handle = cleaned_data.get('twitter_handle')
+        voter.display_name = form.cleaned_data.get('display_name')
+        voter.twitter_handle = form.cleaned_data.get('twitter_handle')
         voter.user = new_user
         voter.save()
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,5 @@ flake8==2.5.1
 pyflakes==1.0.0
 pep8==1.7.0
 mccabe==0.3.1
+factory-boy==2.6.0
+  fake-factory==0.5.3

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,4 +4,4 @@ set -e
 find . -name '*.pyc' -delete
 flake8 .
 coverage run manage.py test --keepdb "$@"
-coverage report -m --fail-under 30  # FIXME: increase minimum requirement to 80 ASAP
+coverage report -m --fail-under 40  # FIXME: increase minimum requirement to 80 ASAP


### PR DESCRIPTION
I've only included the functionality available from the site itself. (Password reset links work, for example, but are not linked anywhere on the site)

Note that I had to change the code a little to get it to work with django-registration-redux. I upgraded that package from 1.1 to 1.3 in a previous PR in order to get Travis to succeed because version 1.1 did not have any migrations and 1.2+ did. Unfortunately 1.2 also had an undocumented breaking change to its API (changing the signature of a method).