### PR TITLE
Improve recent events

### DIFF
--- a/opendebates/__init__.py
+++ b/opendebates/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app  # noqa

--- a/opendebates/celery.py
+++ b/opendebates/celery.py
@@ -1,0 +1,26 @@
+"""Initialize celery"""
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+if os.path.exists('opendebates/local_settings.py'):
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opendebates.local_settings")
+else:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opendebates.settings")
+
+from django.conf import settings  # noqa
+
+app = Celery('opendebates')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -10,6 +10,9 @@ from django.utils.translation import ugettext_lazy as _
 from djangohelpers.lib import register_admin
 
 
+RECENT_EVENTS_CACHE_ENTRY = 'recent_events_cache_entry'
+
+
 class Category(models.Model):
 
     name = models.CharField(max_length=255)

--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -137,13 +137,20 @@
     }
 
     if ($("#recent-activity").length === 1) {
-      var fetch = function() {
-        $.get("/recent/", function(resp) {
-          $("#recent-activity").html(resp);
-          setTimeout(fetch, 2000);
-        });
+      var fetch = function(delay) {
+        $.get("/recent/")
+            .done(function (data) {
+              /* If successful, update page */
+              $("#recent-activity").html(data);
+            })
+            .always(function () {
+              /* Wait a little longer each time */
+              delay = delay + 2000;
+              setTimeout(fetch, delay, delay);
+            });
       };
-      setTimeout(fetch);
+      /* Run first time immediately, to fill in that part of the page */
+      setTimeout(fetch, 0, 0);
     }
   });
 

--- a/opendebates/tasks.py
+++ b/opendebates/tasks.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+import logging
+
+from celery import shared_task
+from django.core.cache import cache
+from django.db.models import F
+
+from opendebates.models import Vote, Submission, RECENT_EVENTS_CACHE_ENTRY
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def update_recent_events():
+    """
+    Compute recent events and cache them for the recent events view to use.
+    """
+    logger.debug("update_recent_events: started")
+
+    votes = Vote.objects.select_related(
+        "voter", "voter__user", "submission").exclude(
+        voter=F('submission__voter')).order_by("-id")[:10]
+    submissions = Submission.objects.select_related(
+        "voter", "voter__user").order_by("-id")[:10]
+
+    entries = list(votes) + list(submissions)
+    entries = sorted(entries, key=lambda x: x.created_at, reverse=True)[:10]
+
+    cache.set(RECENT_EVENTS_CACHE_ENTRY, entries, 30)
+
+    logger.debug("There are %d entries" % len(entries))

--- a/opendebates/tests/factories.py
+++ b/opendebates/tests/factories.py
@@ -1,3 +1,4 @@
+import random
 import string
 
 from django.contrib.auth import get_user_model
@@ -6,6 +7,9 @@ import factory
 import factory.fuzzy
 
 from opendebates import models
+
+
+_random = random.Random()
 
 
 class UserFactory(factory.DjangoModelFactory):
@@ -33,11 +37,18 @@ class CategoryFactory(factory.DjangoModelFactory):
         model = models.Category
 
 
+class FuzzyEmail(factory.fuzzy.FuzzyText):
+    def fuzz(self):
+        chars = [_random.choice(self.chars) for _i in range(self.length)]
+        return "%s@example.com" % chars
+
+
 class VoterFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Voter
 
     user = factory.SubFactory(UserFactory)
+    email = FuzzyEmail()
     zip = factory.fuzzy.FuzzyText(length=5, chars=string.digits)
 
 

--- a/opendebates/tests/test_recent_events.py
+++ b/opendebates/tests/test_recent_events.py
@@ -1,0 +1,41 @@
+from httplib import OK
+
+from django.test import TestCase
+
+import mock
+
+from opendebates.models import RECENT_EVENTS_CACHE_ENTRY
+from opendebates.tasks import update_recent_events
+from opendebates.tests.factories import VoteFactory
+
+
+class RecentEventsTest(TestCase):
+    def setUp(self):
+        self.vote = VoteFactory()
+
+    def test_computing_recent_events(self):
+        mock_cache = mock.MagicMock()
+        with mock.patch('opendebates.tasks.cache', new=mock_cache):
+            update_recent_events()
+        mock_cache.set.assert_called_with(
+            RECENT_EVENTS_CACHE_ENTRY,
+            [self.vote, self.vote.submission],
+            30
+        )
+
+    def test_view_returns_events(self):
+        mock_cache = mock.MagicMock()
+        vote2 = VoteFactory()
+        mock_cache.get.return_value = [
+            vote2,
+            vote2.submission,
+            self.vote,
+            self.vote.submission
+        ]
+        with mock.patch('opendebates.views.cache', new=mock_cache):
+            rsp = self.client.get('/recent/')
+        mock_cache.get.assert_called_with(RECENT_EVENTS_CACHE_ENTRY, default=[])
+        self.assertEqual(OK, rsp.status_code)
+        html = rsp.content.decode('UTF-8')
+        self.assertIn(vote2.submission.idea, html)
+        self.assertIn(self.vote.submission.idea, html)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ django-redis-cache==1.3.0
 django-cache-machine==0.9.1
 newrelic==2.44.0.36
 
-django-celery==3.1.16
+django-celery==3.1.17
 Celery==3.1.18
 kombu==3.0.26
 amqp==1.4.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,5 @@ factory-boy==2.6.0
   fake-factory==0.5.3
 
 fabulaws==0.3.0a2
+
+mock==1.3.0


### PR DESCRIPTION
* Pages that query for recent events were doing it
  every 2 seconds. Gradually increase the time between
  queries (add 2 seconds each time) so that people who
  are clicking around the site will see the same behavior,
  but anyone who opens the page then goes to lunch will not
  keep hitting us every 2 seconds the whole time they're gone.

* If the page's query for recent events fails, still schedule
  the next update.

* Instead of hitting the DB for recent events every time any request
  comes in, have a background task do the query every ten seconds
  and put the result in the cache, then all view requests can just
  get the result from the cache and never have to hit the DB.