### PR TITLE
Add tests for source cookie behavior (and fix behavior for one test failure)

### DIFF
--- a/opendebates/tests/test_submission.py
+++ b/opendebates/tests/test_submission.py
@@ -93,3 +93,31 @@ class SubmissionTest(TestCase):
         rsp = self.client.get(questions_url)
         self.assertEqual(200, rsp.status_code)
         self.assertIn('form', rsp.context)
+
+    def test_post_submission_with_source(self):
+        "An opendebates.source cookie will be transmitted to the submission and vote."
+        source = "a-source-code"
+        self.client.cookies['opendebates.source'] = source
+        rsp = self.client.post(self.url, data=self.data)
+        submission = Submission.objects.first()
+        self.assertRedirects(rsp, submission.get_absolute_url())
+        # Check the Submission attributes
+        self.assertEqual(submission.voter, self.voter)
+        self.assertEqual(submission.source, source)
+
+        votes = Vote.objects.filter(voter=self.voter)
+        self.assertEqual(1, len(votes))
+        self.assertEqual(votes[0].source, source)
+
+    def test_post_submission_without_source(self):
+        "If no opendebates.source cookie is present, vote and submission source will be None"
+        rsp = self.client.post(self.url, data=self.data)
+        submission = Submission.objects.first()
+        self.assertRedirects(rsp, submission.get_absolute_url())
+        # Check the Submission attributes
+        self.assertEqual(submission.voter, self.voter)
+        self.assertEqual(submission.source, None)
+
+        votes = Vote.objects.filter(voter=self.voter)
+        self.assertEqual(1, len(votes))
+        self.assertEqual(votes[0].source, None)        

--- a/opendebates/tests/test_submission.py
+++ b/opendebates/tests/test_submission.py
@@ -120,4 +120,4 @@ class SubmissionTest(TestCase):
 
         votes = Vote.objects.filter(voter=self.voter)
         self.assertEqual(1, len(votes))
-        self.assertEqual(votes[0].source, None)        
+        self.assertEqual(votes[0].source, None)

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -317,12 +317,16 @@ def questions(request):
 
     if 'opendebates.source' in request.COOKIES:
         idea.source = request.COOKIES['opendebates.source']
+        vote_source = request.COOKIES['opendebates.source']
+    else:
+        vote_source = None
 
     idea.save()
 
     Vote.objects.create(
         submission=idea,
         voter=voter,
+        source=vote_source,
         ip_address=get_ip_address_from_request(request),
         request_headers=get_headers_from_request(request),
         created_at=timezone.now())


### PR DESCRIPTION
I wanted to add some tests for the behavior of the "opendebates.source" cookie since it's pretty buried in code and easy to lose track of.

On the front end, this cookie is set or updated by Javascript whenever a page is loaded with a ?source= query string parameter.

It's then tracked in Vote, Voter, and Submission objects so that we can (a) see if different email messages (each with its own ?source=test-version-code links) impact conversion rates, and (b) track acquisitions from partner organizations when they email their members or post links online (each with its own ?source=partner-org link)