### PR TITLE
Use django-balancer to route reads to slave DBs

### DIFF
--- a/deployment/templates/local_settings.py
+++ b/deployment/templates/local_settings.py
@@ -57,6 +57,10 @@ DATABASE_POOL = {
 }
 MASTER_DATABASE = '{{ master_database.database_key }}'
 
+DATABASE_ROUTERS = [
+    'balancer.routers.RoundRobinMasterSlaveRouter',
+]
+
 # media roots
 MEDIA_ROOT = "{{ media_root }}"
 STATIC_ROOT = "{{ static_root }}"


### PR DESCRIPTION
It looks like this was almost all set up already
and all we needed to do was set the database
router.

Let's not merge this yet, until we have baseline
performance numbers and can see whether adding
this in helps. But I'd like to have it reviewed and
ready when that time comes.