### PR TITLE
Question form bugfixes

### DIFF
--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -63,6 +63,12 @@
     });
   };
 
+  $("#sidebar_question_btn").on("click", function() {
+    $(this).hide();
+    $('#add_question_form_well').slideDown();
+    return false;
+  });
+
   $(".search-only form .input-group-addon").on("click", function () {
     $(this).closest("form").submit();
   });

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -171,6 +171,10 @@ body {
 .form-well {
   width: 100%;
   display: none;
+
+  &#add_question_form_well.has-errors {
+    display: block;
+  }
 }
 
 .form-well h2, {

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -37,8 +37,7 @@
         <div class="control-group">
           <div class="controls">
             <textarea id="question" name="question" type="text" rows="4" class="input-large"
-                      value="{{ form.data.question }}"
-                      placeholder="{% blocktrans %}Enter your question here. If you have multiple&nbsp;questions, please submit each one separately."{% endblocktrans %}></textarea>
+                      placeholder="{% blocktrans %}Enter your question here. If you have multiple&nbsp;questions, please submit each one separately."{% endblocktrans %}>{{ form.data.question }}</textarea>
             {% if form.errors.question %}
             <p class="help-block">{{ form.errors.question }}</p>
             {% endif %}

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -1,10 +1,10 @@
 {% load i18n %}
-<div id="sidebar_question_btn" onclick="$(this).hide(); $('.form-well').slideDown(); return false;">
+<div id="sidebar_question_btn" {% if form.errors %}class="hidden"{% endif %}>
   <a href="{% url 'questions' %}" class="btn btn-block btn-primary active" type="button">
     {% blocktrans %}Submit a New Question{% endblocktrans %}
   </a>
 </div>
-<div class="form-well">
+<div id="add_question_form_well" class="form-well{% if form.errors %} has-errors{% endif %}">
   <div id="add_question" name="add_question">
     
     <hr class="mic_icon"/>

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -50,7 +50,7 @@
           <div class="controls">
             <input id="citation" name="citation" type="text" class="input-large" value="{{ form.data.citation }}"
                    placeholder="{% blocktrans %}Citation{% endblocktrans %}">
-            {% if form.errors.idea %}
+            {% if form.errors.citation %}
             <p class="help-block">{{ form.errors.citation }}</p>
             {% endif %}
           </div>

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -23,7 +23,7 @@
             <select name="category">
               <option>--</option>
               {% for iter_category in SUBMISSION_CATEGORIES %}
-              <option {% if category and iter_category.id == category.id %}selected{% endif %}
+              <option {% if iter_category.id|slugify == form.data.category or iter_category.id == category.id %}selected{% endif %}
                       value="{{ iter_category.id }}">{{ iter_category.name }}</option>
               {% endfor %}
             </select>


### PR DESCRIPTION
Fixed these question form bugs you pointed out:

* The question form is opened as a JS reveal, but after form submit, the form is not expanded so you can't see the errors until you re-reveal the form.

* On the question form, an error in citation field doesn't display in the form at all.

Also spotted a few more -- on error, the user's submission text and category were being dropped from the re-rendered form.  And I cleaned up some inline javascript while I was there.

I didn't include any tests here since I didn't see anywhere to put HTML-related tests and they're pretty boring fixes anyway. :-) But let me know if I should.