### PR TITLE
Celery fixes

### DIFF
--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -66,7 +66,7 @@
 
 # Mapping of celery worker names to options
   celery_workers:
-    main: -c 10 -Q celeryd
+    main: -c 10
 
 # Mapping of environment names to domain names. Used to update the
 # primary site in the database after a refresh and to set ALLOWED_HOSTS

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,9 @@ dotenv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".env"))
 dotenv.read_dotenv(dotenv_path)
 
 if __name__ == "__main__":
-    if os.path.exists('opendebates/local_settings.py'):
+    code_root = os.path.dirname(__file__)
+    local_settings = os.path.join(code_root, 'opendebates', 'local_settings.py')
+    if os.path.exists(local_settings):
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opendebates.local_settings")
     else:
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opendebates.settings")

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -128,9 +128,9 @@ CELERYBEAT_SCHEDULE = {
         'task': 'opendebates.tasks.update_recent_events',
         'schedule': timedelta(seconds=10),
         'options': {
-            # If no worker runs it within 10 seconds, throw it away; another
-            # task will already have been scheduled.
-            'expires': 10,  # seconds
+            # If no worker runs it within 60 seconds, throw it away; more
+            # tasks will already have been scheduled.
+            'expires': 60,  # seconds
         }
     },
 }


### PR DESCRIPTION
* Don't pass "-Q celeryd" to the celery worker
* Allow for not being in the code root directory when
  looking to see if there's a local_settings file
* Give tasks a little longer to expire, in case server
  clocks have drifted.