### PR TITLE
Set up new testing env on opendebates aws

### DIFF
--- a/DEPLOY.rst
+++ b/DEPLOY.rst
@@ -194,9 +194,11 @@ yet, you can run this command to set them all up at once::
 
     fab create_environment:opendebates,<environment>
 
-It'll take a while (30 minutes? an hour?) but you only need to do it
-once per environment.  After that, you can follow the instructions below
-for updating things.
+This took 17 minutes the last time I tried it, which doesn't seem bad
+at all (with system sizes like c3.large and m3.large or faster).
+
+You only need to do it once per environment.  After that, you can follow
+the instructions below for updating things.
 
 Updating code
 -------------

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -82,6 +82,7 @@
     testing:
     - opendebates-testing-lb-476601241.us-east-1.elb.amazonaws.com
     - testing.openforum2016.com
+    - testing.demopenforum.com
 
 ## ENVIRONMENT / ROLE SETTINGS ##
 

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -78,11 +78,10 @@
     production:
     -
     staging:
-    - dualstack.opendebates-staging-lb-1737156337.us-east-1.elb.amazonaws.com
+    -
     testing:
-    - testing.demopenforum.com
-    - opendebates-testing.cakt.us
-    - dualstack.opendebates-testing-lb-1802486946.us-east-1.elb.amazonaws.com
+    - opendebates-testing-lb-476601241.us-east-1.elb.amazonaws.com
+    - testing.openforum2016.com
 
 ## ENVIRONMENT / ROLE SETTINGS ##
 
@@ -105,7 +104,7 @@
   region: us-east-1
   avail_zones:
   - b
-  - c
+  - d
 
 # Mapping of role to security group(s):
   security_groups:
@@ -123,13 +122,13 @@
       db-slave: m3.xlarge
       web: c3.large
       worker: m3.large
-    staging:
+    testing:
       cache: c3.large
       db-master: m3.xlarge
       db-slave: m3.xlarge
       web: c3.large
       worker: m3.large
-    testing:
+    staging:
       cache: t1.micro
       db-master: t1.micro
       db-slave: t1.micro
@@ -141,7 +140,7 @@
   load_balancers:
     opendebates:
       production:
-      - opendebates-production-1
+      - opendebates-production-lb
       staging:
       - opendebates-staging-lb
       testing:
@@ -163,13 +162,13 @@
       db-slave: 100
       web: 10
       worker: 50
-    staging:
+    testing:
       cache: 10
       db-master: 100
       db-slave: 100
       web: 10
       worker: 50
-    testing:
+    staging:
       cache: 10
       db-master: 100
       db-slave: 100
@@ -196,3 +195,66 @@
     - build-essential
     - stunnel4
     - pgbouncer
+
+  db_settings:
+    # for help adjusting these settings, see:
+    # http://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
+    # http://wiki.postgresql.org/wiki/Number_Of_Database_Connections
+    # http://thebuild.com/presentations/not-my-job-djangocon-us.pdf
+    postgresql_settings:
+      # Settings to apply to Postgres servers
+      # You can put anything here from postgresql.conf
+
+      # connections
+      max_connections: '80' # _active_ connections are limited by pgbouncer
+
+      # replication settings
+      wal_level: 'hot_standby'
+      hot_standby: 'on'
+      hot_standby_feedback: 'on'
+      max_wal_senders: '3'
+      wal_keep_segments: '3000' # during client deletion 50 or more may be generated per minute; this allows an hour
+
+      # resources - let pgtune set these based on actual machine resources
+      # shared_buffers: '8GB' # 25% of available RAM, up to 8GB
+      # work_mem: '750MB' # (2*RAM)/max_connections
+      # maintenance_work_mem': '1GB' # RAM/16 up to 1GB; high values aren't that helpful
+      # effective_cache_size': '48GB' # between 50-75%, should equal free + cached values in `top`
+
+      # checkpoint settings
+      wal_buffers: '16MB'
+      checkpoint_completion_target: '0.9'
+      checkpoint_timeout: '10min'
+      checkpoint_segments: '256' # if checkpoints are happening more often than the timeout, increase this up to 256
+
+      # logging
+      log_min_duration_statement: '500'
+      log_checkpoints: 'on'
+      log_lock_waits: 'on'
+      log_temp_files: '0'
+
+      # write optimizations
+      commit_delay: '4000' # delay each commit this many microseconds in case we can do a group commit
+      commit_siblings: '5' # only delay if at least N transactions are in process
+
+      # index usage optimizations
+      random_page_cost: '2' # our DB servers have a lot of RAM and may tend to prefer Seq Scans if this is too high
+
+    # More Postgres-related settings.
+    # How to install Postgres:
+    postgresql_packages:
+      - postgresql
+      - libpq-dev
+    # Whether and how to apply pgtune
+    postgresql_tune: true
+    postgresql_tune_type: Web
+    # Kernel sysctl settings to change
+    postgresql_shmmax: 107374182400  # 100 GB
+    postgresql_shmall: 26214400  # 100 GB / PAGE_SIZE (4096)
+    # Networks to allow connections from
+    postgresql_networks:
+      - '0.0.0.0/0'
+      - '10.0.0.0/8'
+      - '172.0.0.0/8'
+    # Whether to disable the Linux out-of-memory killer
+    postgresql_disable_oom: true


### PR DESCRIPTION
* Update hostnames mainly
* Swap the 'testing' and 'staging' env names in the config
* Add the db settings to the config, including allowing postgres
  replication from any network address. AWS security groups should
  still keep this secure, but we should tighten this down at some
  point.