### PR TITLE
increase server sizes

### DIFF
--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -70,7 +70,7 @@
     main: -c 10
 
 # Start this many Gunicorn workers for each CPU core
-  gunicorn_worker_multipler: 4
+  gunicorn_worker_multiplier: 4
 
 # Mapping of environment names to domain names. Used to update the
 # primary site in the database after a refresh and to set ALLOWED_HOSTS

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -1,6 +1,5 @@
   instance_settings:
     # http://uec-images.ubuntu.com/releases/trusty/release/
-    ami: ami-b2e3c6d8 # us-east-1 14.04.3 LTS 64-bit w/EBS-SSD root store
     ami: ami-35d6f95f # us-east-1 14.04.3 LTS 64-bit hvm-ssd
     key_prefix: 'opendebates-'
     admin_groups: [admin, sudo]

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -1,6 +1,7 @@
   instance_settings:
     # http://uec-images.ubuntu.com/releases/trusty/release/
     ami: ami-b2e3c6d8 # us-east-1 14.04.3 LTS 64-bit w/EBS-SSD root store
+    ami: ami-35d6f95f # us-east-1 14.04.3 LTS 64-bit hvm-ssd
     key_prefix: 'opendebates-'
     admin_groups: [admin, sudo]
     run_upgrade: true
@@ -127,11 +128,11 @@
       web: c3.large
       worker: m3.large
     testing:
-      cache: c3.large
-      db-master: m3.xlarge
-      db-slave: m3.xlarge
-      web: c3.large
-      worker: m3.large
+      cache: c4.large
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c4.xlarge
+      worker: m4.large
     staging:
       cache: t1.micro
       db-master: t1.micro

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -130,7 +130,7 @@
       cache: c4.large
       db-master: m4.2xlarge
       db-slave: m4.2xlarge
-      web: c4.xlarge
+      web: c3.large
       worker: m4.large
     staging:
       cache: t1.micro

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -70,7 +70,7 @@
     main: -c 10
 
 # Start this many Gunicorn workers for each CPU core
-  gunicorn_worker_multipler: 8
+  gunicorn_worker_multipler: 4
 
 # Mapping of environment names to domain names. Used to update the
 # primary site in the database after a refresh and to set ALLOWED_HOSTS

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,6 @@ mccabe==0.3.1
 factory-boy==2.6.0
   fake-factory==0.5.3
 
-fabulaws==0.3.0a8
+fabulaws==0.3.0a9
 
 mock==1.3.0


### PR DESCRIPTION
- switch to c4 and m4 generation instances
- double DB server size (make sure one DB server can handle the load of 120k+ req/sec)
- double web server size (avoid hitting 50 server EC2 account limit)