### PR TITLE
Display "vote form" validation errors in "vote" popup

### DIFF
--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -56,6 +56,13 @@
         $(".big-idea[data-idea-id="+resp.id+"]").find(".vote-button").hide();
         $(".big-idea[data-idea-id="+resp.id+"]").find(".already-voted-button").css("display", "block");
 
+      } else {
+        $.each(resp.errors, function(key, vals) {
+          $('#modal-vote').find(':input[name='+key+']')
+            .closest('.controls')
+            .find('.help-block')
+            .html(vals.join(' '));
+        });
       }
       if (typeof callback === 'function') {
         callback(resp);

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -431,6 +431,12 @@ hr.mic_icon:after {
   font-weight: 200;
   font-size: .9em;
 }
+.help-block {
+  font-size: 12px;
+  color: white;
+  font-weight: bold;
+  margin-bottom: -5px;
+}
 
 .navbar-default {
   background-color: darken(@brand-primary, 3%);

--- a/opendebates/templates/opendebates/snippets/vote_modal.html
+++ b/opendebates/templates/opendebates/snippets/vote_modal.html
@@ -15,6 +15,7 @@
             <div class="control-group">
               <label class="control-label" for="email"></label>
               <div class="controls">
+                <p class="help-block"></p>
                 <input name="email" type="text" class="input-large required"
                        placeholder="{% blocktrans %}Email{% endblocktrans %}">
               </div>
@@ -23,6 +24,7 @@
             <div class="control-group">
               <label class="control-label" for="zipcode"></label>
               <div class="controls">
+                <p class="help-block"></p>
                 <input name="zipcode" type="text" class="input-large required"
                        placeholder="{% blocktrans %}Zip code{% endblocktrans %}">
               </div>


### PR DESCRIPTION
* When view returns a `{"status": "400", "errors": {..}}` object, javascript finds an input corresponding to each error key, and inserts error text in a nearby `<p class="help-block">` that's contained within the same `<div class="control">`.

* I didn't spend much time on the CSS since it will obviously all change with the designs.  (Looks like the new designs have a white popup background, so red text should work there.  But for now I used white text to go better with the blue popup background that we currently have.)

* I didn't think it was worth writing cleaner javascript code here but let me know if you disagree.

* And let me know if there's anything worth writing tests for in this (pretty sure there isn't)