### PR TITLE
Cache some models

### DIFF
--- a/opendebates/migrations/0014_auto_20160203_2029.py
+++ b/opendebates/migrations/0014_auto_20160203_2029.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0013_auto_20160109_1701'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='approved',
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='submission',
+            name='has_duplicates',
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -8,15 +8,18 @@ from djorm_pgfulltext.fields import VectorField
 from urllib import quote_plus
 from django.utils.translation import ugettext_lazy as _
 from djangohelpers.lib import register_admin
+from caching.base import CachingManager, CachingMixin
 
 
 NUMBER_OF_VOTES_CACHE_ENTRY = 'number_of_votes'
 RECENT_EVENTS_CACHE_ENTRY = 'recent_events_cache_entry'
 
 
-class Category(models.Model):
+class Category(CachingMixin, models.Model):
 
     name = models.CharField(max_length=255)
+
+    objects = CachingManager()
 
     def __unicode__(self):
         return self.name
@@ -47,8 +50,8 @@ class Submission(models.Model):
     ip_address = models.CharField(max_length=255, db_index=True)
 
     editors_pick = models.BooleanField(default=False)
-    approved = models.BooleanField(default=False)
-    has_duplicates = models.BooleanField(default=False)
+    approved = models.BooleanField(default=False, db_index=True)
+    has_duplicates = models.BooleanField(default=False, db_index=True)
 
     duplicate_of = models.ForeignKey('opendebates.Submission', null=True, blank=True,
                                      related_name="duplicates")
@@ -133,10 +136,12 @@ class Submission(models.Model):
             }
 
 
-class ZipCode(models.Model):
+class ZipCode(CachingMixin, models.Model):
     zip = models.CharField(max_length=10, unique=True)
     city = models.CharField(max_length=255, null=True, blank=True)
     state = models.CharField(max_length=255, null=True, blank=True)
+
+    objects = CachingManager()
 
 
 class Voter(models.Model):

--- a/opendebates/tests/test_router.py
+++ b/opendebates/tests/test_router.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from mock import Mock
 
+from opendebates.models import Submission
 from opendebates.router import DBRouter, is_thread_readwrite, set_thread_readwrite_db, \
     set_thread_readonly_db, set_db_written_flag, was_db_written, clear_db_written_flag, \
     DBRoutingMiddleware, PINNING_KEY
@@ -94,12 +95,12 @@ class DBRouterTest(TestCase):
 
     def test_writing_sets_db_written_flag(self):
         router = DBRouter()
-        router.db_for_read(None)
+        router.db_for_read(Submission)
         self.assertFalse(was_db_written())
-        router.db_for_write(None)
+        router.db_for_write(Submission)
         self.assertTrue(was_db_written())
         # A read won't reset the flag
-        router.db_for_read(None)
+        router.db_for_read(Submission)
         self.assertTrue(was_db_written())
 
     def test_readwrite(self):
@@ -108,9 +109,9 @@ class DBRouterTest(TestCase):
         master = 'my_master_db'
         with override_settings(MASTER_DATABASE=master):
             router = DBRouter()
-            out = router.db_for_read(None)
+            out = router.db_for_read(Submission)
             self.assertEqual(master, out)
-            out = router.db_for_write(None)
+            out = router.db_for_write(Submission)
             self.assertEqual(master, out)
         self.assertTrue(was_db_written())
 
@@ -122,9 +123,9 @@ class DBRouterTest(TestCase):
         }
         with override_settings(DATABASE_POOL=pool):
             router = DBRouter()
-            out = router.db_for_read(None)
+            out = router.db_for_read(Submission)
             self.assertEqual(replica, out)
-            out = router.db_for_read(None)
+            out = router.db_for_read(Submission)
             self.assertEqual(replica, out)
         self.assertFalse(was_db_written())
 
@@ -141,15 +142,15 @@ class DBRouterTest(TestCase):
         replicas = pool.keys()
         with override_settings(DATABASE_POOL=pool):
             router = DBRouter()
-            out0 = router.db_for_read(None)
+            out0 = router.db_for_read(Submission)
             self.assertIn(out0, replicas)
-            out1 = router.db_for_read(None)
+            out1 = router.db_for_read(Submission)
             self.assertIn(out1, replicas)
             self.assertNotEqual(out0, out1)
-            out2 = router.db_for_read(None)
+            out2 = router.db_for_read(Submission)
             self.assertIn(out2, replicas)
             self.assertNotEqual(out1, out2)
-            out3 = router.db_for_read(None)
+            out3 = router.db_for_read(Submission)
             # Round-robin should have come around by now
             self.assertEqual(out3, out0)
         self.assertFalse(was_db_written())


### PR DESCRIPTION
More specifically:

* Add django-cache-machine to Category and Zipcode
* Tweak the DB router to more agressively send reads
  for those two models to the replica
* Add a couple of database indexes based on some queries
  I saw locally (using DDT to check out what queries common
  pages used).