### PR TITLE
Remove too-long dropdowns from admin

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -1,0 +1,37 @@
+from django.contrib.admin import ModelAdmin, register
+from djangohelpers.export_action import admin_list_export
+
+from . import models
+
+
+@register(models.Category)
+class CategoryAdmin(ModelAdmin):
+    list_display = [f.name for f in models.Category._meta.fields]
+    actions = [admin_list_export]
+
+
+@register(models.Submission)
+class SubmissionAdmin(ModelAdmin):
+    list_display = [f.name for f in models.Submission._meta.fields]
+    actions = [admin_list_export]
+    raw_id_fields = ['voter', 'duplicate_of']
+
+
+@register(models.Voter)
+class VoterAdmin(ModelAdmin):
+    list_display = [f.name for f in models.Voter._meta.fields]
+    actions = [admin_list_export]
+    raw_id_fields = ['user', ]
+
+
+@register(models.Vote)
+class VoteAdmin(ModelAdmin):
+    list_display = [f.name for f in models.Vote._meta.fields]
+    actions = [admin_list_export]
+    raw_id_fields = ['submission', 'voter', 'original_merged_submission']
+
+
+@register(models.Candidate)
+class CandidateAdmin(ModelAdmin):
+    list_display = [f.name for f in models.Candidate._meta.fields]
+    actions = [admin_list_export]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -7,7 +7,6 @@ from djorm_pgfulltext.models import SearchManager
 from djorm_pgfulltext.fields import VectorField
 from urllib import quote_plus
 from django.utils.translation import ugettext_lazy as _
-from djangohelpers.lib import register_admin
 from caching.base import CachingManager, CachingMixin
 
 
@@ -231,9 +230,3 @@ class Candidate(models.Model):
 
     def __unicode__(self):
         return self.display_name
-
-register_admin(Category)
-register_admin(Submission)
-register_admin(Voter)
-register_admin(Vote)
-register_admin(Candidate)


### PR DESCRIPTION
Once the site is populated, clicking on one of the admin pages can take >30 sec to load all the instances into the dropdowns, which would affect the rest of the site.

This makes all dropdown fields `raw_id_fields` which would prevent that.