### PR TITLE
Allow disabling captcha

### DIFF
--- a/deployment/templates/local_settings.py
+++ b/deployment/templates/local_settings.py
@@ -189,3 +189,4 @@ DBBACKUP_HOSTNAME = ALLOWED_HOSTS[0]
 
 NORECAPTCHA_SITE_KEY = '{{ recaptcha_site_key }}'
 NORECAPTCHA_SECRET_KEY = '{{ recaptcha_secret }}'
+USE_CAPTCHA = {{ use_captcha|default(true, true) }}

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -26,7 +26,8 @@
   password_names: [database_password, broker_password, smtp_password,
                    newrelic_license_key, newrelic_api_key, s3_secret,
                    secret_key, dbbackup_access_key, dbbackup_access_secret,
-                   syslog_server, recaptcha_site_key, recaptcha_secret]
+                   syslog_server, recaptcha_site_key, recaptcha_secret,
+                   use_captcha]
   project: opendebates
   wsgi_app: opendebates.wsgi:application
   requirements_file: requirements/base.txt

--- a/opendebates/forms.py
+++ b/opendebates/forms.py
@@ -91,6 +91,9 @@ class OpenDebatesRegistrationForm(RegistrationForm):
             user.save()
         return user
 
+    def ignore_captcha(self):
+        del self.fields['captcha']
+
 
 class OpenDebatesAuthenticationForm(AuthenticationForm):
     username = forms.CharField(max_length=254,

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -267,3 +267,6 @@ DBBACKUP_SEND_EMAIL = False
 # https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-test-with-recaptcha-v2-how-should-i-do
 NORECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
 NORECAPTCHA_SECRET_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+
+# Turn this off to never use CAPTCHA
+USE_CAPTCHA = True

--- a/opendebates/tests/test_registration.py
+++ b/opendebates/tests/test_registration.py
@@ -3,6 +3,7 @@ import os
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from .factories import UserFactory
 
@@ -24,7 +25,7 @@ class RegisterTest(TestCase):
         os.environ['NORECAPTCHA_TESTING'] = 'True'
 
     def tearDown(self):
-        del os.environ['NORECAPTCHA_TESTING']
+        os.environ.pop('NORECAPTCHA_TESTING', '')
 
     def test_registration_get(self):
         "GET the form successfully."
@@ -77,6 +78,16 @@ class RegisterTest(TestCase):
             rsp = self.client.post(self.url, data=data)
             form = rsp.context['form']
             self.assertEqual('twitter', form.cleaned_data['twitter_handle'])
+
+    @override_settings(USE_CAPTCHA=False)
+    def test_disabling_captcha(self):
+        del self.data['g-recaptcha-response']
+        del os.environ['NORECAPTCHA_TESTING']
+        home_url = reverse('list_ideas')
+        rsp = self.client.post(self.url, data=self.data, follow=True)
+        self.assertRedirects(rsp, home_url)
+        new_user = get_user_model().objects.first()
+        self.assertEqual(new_user.first_name, self.data['first_name'])
 
 
 class LoginLogoutTest(TestCase):

--- a/opendebates/tests/test_utils.py
+++ b/opendebates/tests/test_utils.py
@@ -1,0 +1,42 @@
+from django.test import TestCase, override_settings
+from mock import Mock, patch
+
+from opendebates.tests.factories import VoteFactory
+from opendebates.utils import registration_needs_captcha, vote_needs_captcha
+
+
+@override_settings(USE_CAPTCHA=True)
+class TestCaptchaUtils(TestCase):
+    def setUp(self):
+        self.mock_request = Mock(spec=object)
+
+    def test_registration_captcha(self):
+        self.assertTrue(registration_needs_captcha(self.mock_request))
+
+    @override_settings(USE_CAPTCHA=False)
+    def test_registration_captcha_disabled(self):
+        self.assertFalse(registration_needs_captcha(self.mock_request))
+
+    @override_settings(USE_CAPTCHA=False)
+    def test_vote_captcha_disabled(self):
+        self.assertFalse(vote_needs_captcha(self.mock_request))
+
+    def test_vote_captcha_no_voter(self):
+        # first vote requires captcha
+        with patch('opendebates.utils.get_voter') as mock_get_voter:
+            mock_get_voter.return_value = {}
+            self.assertTrue(vote_needs_captcha(self.mock_request))
+
+    def test_vote_captcha_first_vote(self):
+        # first vote requires captcha even if voter exists
+        with patch('opendebates.utils.get_voter') as mock_get_voter:
+            mock_get_voter.return_value = {'email': 'nevervoted@example.com'}
+            self.assertTrue(vote_needs_captcha(self.mock_request))
+
+    def test_vote_captcha_second_vote(self):
+        # second vote does not require captcha
+        email = 'hasvoted@example.com'
+        VoteFactory(voter__email=email)
+        with patch('opendebates.utils.get_voter') as mock_get_voter:
+            mock_get_voter.return_value = {'email': email}
+            self.assertFalse(vote_needs_captcha(self.mock_request))

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -1,12 +1,15 @@
 import json
 import random
 
+from django.conf import settings
 from django.core.cache import cache
 
 from .models import Vote, Voter, NUMBER_OF_VOTES_CACHE_ENTRY
 
 
 def vote_needs_captcha(request):
+    if not settings.USE_CAPTCHA:
+        return False
     if not hasattr(request, 'vote_needs_captcha'):
         voter = get_voter(request)
         if voter:
@@ -16,6 +19,10 @@ def vote_needs_captcha(request):
             need = True
         request.vote_needs_captcha = need
     return request.vote_needs_captcha
+
+
+def registration_needs_captcha(request):
+    return settings.USE_CAPTCHA
 
 
 def get_number_of_votes():

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -18,7 +18,7 @@ from .forms import OpenDebatesRegistrationForm, VoterForm, QuestionForm
 from .models import Submission, Voter, Vote, Category, Candidate, ZipCode, RECENT_EVENTS_CACHE_ENTRY
 from .router import readonly_db
 from .utils import get_ip_address_from_request, get_headers_from_request, choose_sort, sort_list, \
-    vote_needs_captcha
+    vote_needs_captcha, registration_needs_captcha
 # from opendebates_comments.forms import CommentForm
 from opendebates_emails.models import send_email
 
@@ -347,6 +347,12 @@ class OpenDebatesRegistrationView(RegistrationView):
             )
         )
         return new_user
+
+    def get_form(self, form_class=None):
+        form = super(OpenDebatesRegistrationView, self).get_form(form_class)
+        if not registration_needs_captcha(self.request):
+            form.ignore_captcha()
+        return form
 
 
 def registration_complete(request):


### PR DESCRIPTION
New setting USE_CAPTCHA can be set False (but defaults to True).

On deploy will get value from secret 'use_captcha'. To change deployed
value, edit local fabsecrets.py, then

        fab testing update_server_passwords supervisor:restart,web