### PR TITLE
Change how we call grecaptcha.reset()

### DIFF
--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -1,6 +1,6 @@
 (function() {
   var ODebates = window.ODebates || {};
-  var grecaptcha = window.grecaptcha;
+
   ODebates.helpers = ODebates.helpers || {};
 
   ODebates.helpers.getParameterByName = function(name) {
@@ -71,7 +71,7 @@
         /* Reset captcha if the form had errors, because we can only
            validate a captcha token once, so we'll need a new one for
            the next time they submit. */
-        grecaptcha.reset();
+        window.grecaptcha.reset();
       }
       if (typeof callback === 'function') {
         callback(resp);


### PR DESCRIPTION
The code was setting a var at a higher level
to the value of window.grecaptcha, then using that.
But on Firefox that resulted in an undefined variable.
Change to just calling `window.grecaptcha.reset()`.