### PR TITLE
Fix use_captcha when False

### DIFF
--- a/deployment/templates/local_settings.py
+++ b/deployment/templates/local_settings.py
@@ -189,4 +189,4 @@ DBBACKUP_HOSTNAME = ALLOWED_HOSTS[0]
 
 NORECAPTCHA_SITE_KEY = '{{ recaptcha_site_key }}'
 NORECAPTCHA_SECRET_KEY = '{{ recaptcha_secret }}'
-USE_CAPTCHA = {{ use_captcha|default(true, true) }}
+USE_CAPTCHA = {{ use_captcha|default(true) }}


### PR DESCRIPTION
Setting default using Jinja was wrong, fixed so
if use_captcha is False, we get USE_CAPTCHA = False
in local_settings.py, and if use_captcha is True or
missing, we get USE_CAPTCH = True in local_settings.py.