### PR TITLE
{OP-77} Fix errors caused by manual POST

### DIFF
--- a/opendebates/tests/test_vote.py
+++ b/opendebates/tests/test_vote.py
@@ -234,3 +234,15 @@ class VoteTest(TestCase):
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         # ... and in DB
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+
+    # non AJAX tests
+
+    def test_vote_email_should_match_user(self):
+        "If user bypasses our web interface and directly POSTs, we should not 500."
+        data = {
+            'email': 'not-the-users-email@example.com',
+            'zipcode': self.voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }
+        rsp = self.client.post(self.submission_url, data=data)
+        self.assertEqual(400, rsp.status_code)

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -9,7 +9,7 @@ from django.db import connections
 from django.db.models import F
 from django.utils import timezone
 from django.utils.translation import ugettext as _
-from django.http import Http404, HttpResponse, HttpResponseServerError
+from django.http import Http404, HttpResponse, HttpResponseServerError, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
 from djangohelpers.lib import rendered_with, allow_http
 from registration.backends.simple.views import RegistrationView
@@ -199,6 +199,11 @@ def vote(request, id):
             # 'comment_form': CommentForm(idea),
             }
     state = state_from_zip(form.cleaned_data['zipcode'])
+
+    if request.user.is_authenticated():
+        if request.user.email != form.cleaned_data['email']:
+            # this can only happen with an manually-created POST request
+            return HttpResponseBadRequest('Incorrect email for user')
 
     voter, created = Voter.objects.get_or_create(
         email=form.cleaned_data['email'],


### PR DESCRIPTION
Our jmeter script registers a user (who remains logged in) and then submits votes with different email addresses. This is not possible via the web interface because email is populated via Ajax from the logged in user object.

This change just prevents jmeter (or malicious user scripts) from causing a 500 error