### PR TITLE
Make sure "headline" field is indexed for search

### DIFF
--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -69,7 +69,7 @@ class Submission(models.Model):
 
     keywords = models.TextField(null=True, blank=True)
 
-    objects = SearchManager(fields=["idea", "keywords"],
+    objects = SearchManager(fields=["idea", "keywords", "headline"],
                             auto_update_search_field=True)
 
     source = models.CharField(max_length=255, null=True, blank=True)


### PR DESCRIPTION
I'm pretty sure this change is needed to make headlines participate in search results at all.  I'll try to add a test to this PR soon - and also check whether changes are needed in the "merge ideas" logic to support headlines too.  But wanted to get this to you as soon as I noticed it.