### PR TITLE
Detail view layout breaks with short headline

### DIFF
--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -886,6 +886,7 @@ body > .container {
   }
   .idea-related {
     flex-grow: 1;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
The `/questions/:id/` layout breaks when a question's headline is short - on my screen at least, 12-13 characters is the breaking point:

<img width="1103" alt="screen shot 2016-02-16 at 8 36 36 am" src="https://cloud.githubusercontent.com/assets/54995/13077699/6f724594-d488-11e5-86d3-22726ab0cc62.png">

No idea if this proposed fix is correct, but it seems to work so I thought I'd start here.