### PR TITLE
Undo lazy pagination

### DIFF
--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -94,7 +94,7 @@
   {% show_current_number as page_number %}
   {% cache 30 idea_list search_term category.id sort page_number %}
   <div class="row idea-list">
-    {% lazy_paginate 25 ideas %}
+    {% paginate 25 ideas %}
 
     {% for idea in ideas %}
       {% include "opendebates/snippets/idea.html" %}


### PR DESCRIPTION
It's probably easiest just to undo the lazy pagination change. Now that this is inside of a cached template fragment that only updates every 30 seconds, it *should* cause much less load to the DB