### PR TITLE
Restore display of merged submissions on question detail screen

### DIFF
--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -87,6 +87,12 @@
     return false;
   });
 
+  $(".show-duplicates a").on("click", function() {
+    $(".duplicates-list").removeClass("hidden");
+    $(".show-duplicates").hide();
+    return false;
+  });
+
   $(".search-only form .input-group-addon").on("click", function () {
     $(this).closest("form").submit();
   });
@@ -154,6 +160,13 @@
 
   $(window).load(function() {
 
+    if (window.location.hash && $(window.location.hash).hasClass("big-idea")) {
+      $(".show-duplicates a").trigger("click");
+      $('html, body').animate({
+        scrollTop: $(window.location.hash).offset().top
+      }, 500);
+    }
+    
     // Break vote count into spans for styling
     $(".header-votes .number").each(function(){
       var $el = $(this);

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -921,8 +921,12 @@ body > .container > footer {
     }
   }
 
+  .big-idea {
+    border-bottom: none;
+  }
+
   .social-side-bar {
-    width: (140px * 2) + 20px;
+    min-width: (140px * 2) + 20px;
 
     .social-links {
       display: flex;

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -967,12 +967,18 @@ body > .container > footer {
     }
   }
   .idea-related {
+    border-top: 1px solid #ccc;
     flex-grow: 1;
     width: 100%;
   }
 }
 
 /* TODO: Review original Stylesheet below */
+.show-duplicates a {
+  text-decoration: underline;
+  font-size: 13px;
+  font-weight: bold;
+}
 
 .recent-activity-entry {
   margin-bottom: 2px;

--- a/opendebates/templates/opendebates/snippets/idea.html
+++ b/opendebates/templates/opendebates/snippets/idea.html
@@ -82,7 +82,10 @@
 </div>
 
 {% if show_duplicates and idea.has_duplicates %}
-<div class="row">
+<div class="show-duplicates">
+  <a href="#">{% blocktrans %}Click to see the questions that were merged into this{% endblocktrans %}</a>
+</div>
+<div class="duplicates-list row hidden">
   <div class="col-xs-12 idea-duplicates-list">
     {% for duplicate in idea.get_duplicates %}
     {% include "opendebates/snippets/idea.html" with idea=duplicate is_duplicate=1 %}

--- a/opendebates/templates/opendebates/snippets/idea.html
+++ b/opendebates/templates/opendebates/snippets/idea.html
@@ -69,8 +69,8 @@
       {% trans "Issue area" %}: <strong>{{ idea.category.name }}</strong>
     </div>
     {% include "opendebates/snippets/social-links.html" %}
-    {% if not idea.duplicate_of %}
     <div class="idea-actions">
+      {% if not idea.duplicate_of %}
       <span>
         <a href="{% url 'merge' idea.pk %}">{% trans "Merge" %}</a>
       </span>

--- a/opendebates/templates/opendebates/vote.html
+++ b/opendebates/templates/opendebates/vote.html
@@ -8,9 +8,11 @@
 
 {% block content %}
 <div class="row question-detail">
-  {% include "opendebates/snippets/idea.html" %}
-
-  <div class="social-side-bar">
+  <div class="col-sm-8">
+    {% include "opendebates/snippets/idea.html" %}
+  </div>
+  
+  <div class="col-sm-4 social-side-bar">
     <h2>Share This Idea!</h2>
 
     {% include "opendebates/snippets/social-links.html" %}

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -174,7 +174,7 @@ def vote(request, id):
         related2 = two_other_approved_ideas[1]
         return {
             'idea': idea,
-            'show_duplicates': False,
+            'show_duplicates': True,
             'related1': related1,
             'related2': related2,
             'duplicates': (Submission.objects.filter(approved=True, duplicate_of=idea)


### PR DESCRIPTION
* Fix mis-nested {% if %} that caused a div to close too early (which is why someone hid these in the first place, I think?)
* Use bootstrap col-sm 8/4 to display question stuff and sidebar side-by-side, and replace calculated sidebar width with a calculated min-width instead
* Use show_duplicates=True
* Clean up border styles for merged ideas
* Hide merged duplicates on page load, with a "Click here" prompt, unless visiting a merged idea directly (e.g. following a link to a submission that has since been merged into another one -- in which case the final URL after redirects will have an anchor hash referencing the merged idea's ID)