### PR TITLE
Adjust a few user/voter edge case behaviors

### DIFF
--- a/opendebates/tests/test_utils.py
+++ b/opendebates/tests/test_utils.py
@@ -9,6 +9,8 @@ from opendebates.utils import registration_needs_captcha, vote_needs_captcha
 class TestCaptchaUtils(TestCase):
     def setUp(self):
         self.mock_request = Mock(spec=object)
+        self.mock_request.user = Mock()
+        self.mock_request.user.is_authenticated = lambda: False
 
     def test_registration_captcha(self):
         self.assertTrue(registration_needs_captcha(self.mock_request))
@@ -32,6 +34,14 @@ class TestCaptchaUtils(TestCase):
         with patch('opendebates.utils.get_voter') as mock_get_voter:
             mock_get_voter.return_value = {'email': 'nevervoted@example.com'}
             self.assertTrue(vote_needs_captcha(self.mock_request))
+
+    def test_vote_captcha_first_vote_loggedin(self):
+        # first vote does not require captcha if user is logged in
+        # even if no prior votes have been cast by the logged in user
+        mock_request_loggedin = Mock(spec=object)
+        mock_request_loggedin.user = Mock()
+        mock_request_loggedin.user.is_authenticated = lambda: True
+        self.assertFalse(vote_needs_captcha(mock_request_loggedin))
 
     def test_vote_captcha_second_vote(self):
         # second vote does not require captcha

--- a/opendebates/tests/test_vote.py
+++ b/opendebates/tests/test_vote.py
@@ -207,6 +207,7 @@ class VoteTest(TestCase):
 
     def test_vote_user_bad_captcha(self):
         # If captcha doesn't pass, no vote
+        self.client.logout()
         data = {
             'email': self.voter.email,
             'zipcode': self.voter.zip,

--- a/opendebates/tests/test_vote.py
+++ b/opendebates/tests/test_vote.py
@@ -164,7 +164,6 @@ class VoteTest(TestCase):
         rsp = self.client.post(self.submission_url, data=data,
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(200, rsp.status_code)
-        json_rsp = json.loads(rsp.content)
         # votes is incremented
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)

--- a/opendebates/tests/test_vote.py
+++ b/opendebates/tests/test_vote.py
@@ -153,8 +153,8 @@ class VoteTest(TestCase):
         self.assertEqual(self.votes + 0, json_rsp['tally'])
         self.assertEqual(self.votes + 0, refetched_sub.votes)
 
-    def test_anon_cant_use_other_users_account(self):
-        "Unauthenticated cannot use an authenticated user's account."
+    def test_anon_can_use_other_users_account(self):
+        "Unauthenticated can use an authenticated user's account."
         self.client.logout()
         data = {
             'email': self.user.email,
@@ -165,10 +165,9 @@ class VoteTest(TestCase):
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(200, rsp.status_code)
         json_rsp = json.loads(rsp.content)
-        # votes is not incremented
+        # votes is incremented
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
-        self.assertEqual(self.votes + 0, refetched_sub.votes)
-        self.assertIn('That email is registered', json_rsp['errors']['email'][0])
+        self.assertEqual(self.votes + 1, refetched_sub.votes)
 
     def test_vote_user(self):
         "Authenticated user can vote."

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -11,12 +11,16 @@ def vote_needs_captcha(request):
     if not settings.USE_CAPTCHA:
         return False
     if not hasattr(request, 'vote_needs_captcha'):
-        voter = get_voter(request)
-        if voter:
-            # A user's first vote requires a captcha
-            need = not Vote.objects.filter(voter__email=voter['email']).exists()
+        if request.user.is_authenticated():
+            # A logged-in user has already filled out the captcha on registration
+            need = False
         else:
-            need = True
+            voter = get_voter(request)
+            if voter:
+                # A user's first vote requires a captcha
+                need = not Vote.objects.filter(voter__email=voter['email']).exists()
+            else:
+                need = True
         request.vote_needs_captcha = need
     return request.vote_needs_captcha
 

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -216,20 +216,6 @@ def vote(request, id):
         )
     )
 
-    if request.user.is_anonymous() and voter.user:
-        # anonymous user can't use the email of a registered user
-        msg = 'That email is registered. Please login and try again.'
-        if request.is_ajax():
-            return HttpResponse(
-                json.dumps({"status": "400", "errors": {'email': [msg]}}),
-                content_type="application/json")
-        messages.error(request, _(msg))
-        return {
-            'form': form,
-            'idea': idea,
-            # 'comment_form': CommentForm(idea),
-        }
-
     if not created and voter.zip != form.cleaned_data['zipcode']:
         voter.zip = form.cleaned_data['zipcode']
         voter.state = state


### PR DESCRIPTION
* Never require a CAPTCHA when a fully logged-in user tries to vote, even if that user has never voted before.  A logged-in user has already passed the CAPTCHA during registration, so getting the vote popup with captcha is unnecessarily confusing.

* Allow an anonymous user to cast votes using an email address that's already associated with a full user account.  While this does allow potential fraudulent votes, we think that tradeoff is worth the added simplicity for returning users -- if someone has previously created an account, and then comes back to the site on another computer or after their login session expires, we don't want to make them log in just to cast a vote.  (If we get worried about the vote fraud problem this creates, we'd prefer to solve that by letting users review and flag their own votes, and/or by giving administrators more tools to spot suspicious vote activity by IP address / location / browser / etc.)