### PR TITLE
Adjust login/register pages to match designs more closely

### DIFF
--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -206,17 +206,11 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/base.js',
     },
-    'home': {
+    'registration': {
         'source_filenames': (
-            'js/home.js',
+            'js/registration.js',
         ),
-        'output_filename': 'js/home.js',
-    },
-    'login': {
-        'source_filenames': (
-            'js/login.js',
-        ),
-        'output_filename': 'js/login.js',
+        'output_filename': 'js/registration.js',
     }
 
 }

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -1174,6 +1174,10 @@ body .flatpage {
     font-size: 0.8em;
   }
 
+  label[for=id_captcha] {
+    display: none;
+  }
+  
   .g-recaptcha > div > div {
     margin: auto;
   }

--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -1168,6 +1168,27 @@ body > .container > footer {
 body .flatpage {
   margin-top: 25px;
   min-height: 600px;
+
+  .control-label {
+    font-weight: 100;
+    font-size: 0.8em;
+  }
+
+  .g-recaptcha > div > div {
+    margin: auto;
+  }
+  
+  ul.form-notes li {
+    list-style-type: none;
+  }
+  
+  .btn {
+    text-transform: uppercase;
+    font-family: Knockout-light;
+    font-size: 28px;
+    letter-spacing: 1px;
+    padding: 20px 60px;
+  }
 }
 
 .recent-activity-container {

--- a/opendebates/templates/registration/login.html
+++ b/opendebates/templates/registration/login.html
@@ -12,8 +12,9 @@
         {{ form|bootstrap }}
         <input class="btn btn-primary" type="submit" value="{% blocktrans %}Log in{% endblocktrans %}" />
         <input type="hidden" name="next" value="{{ next }}" />
-        <div>
-          <a href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a>
+        <br><br>
+        <div class="small">
+          <b><a href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a></b>
         </div>
       </form>
 

--- a/opendebates/templates/registration/login.html
+++ b/opendebates/templates/registration/login.html
@@ -5,21 +5,24 @@
 {% url 'registration_register' as register_url%}
 
   <div class="flatpage row">
-    <div class="col-sm-6">
+    <div class="col-sm-8 col-sm-offset-2 text-center">
 
       {% load bootstrap %}
       <form method="post" action="{% url 'auth_login' %}">{% csrf_token %}
         {{ form|bootstrap }}
-        <input class="btn btn-primary" type="submit" value="Log In" />
+        <input class="btn btn-primary" type="submit" value="{% blocktrans %}Log in{% endblocktrans %}" />
         <input type="hidden" name="next" value="{{ next }}" />
-        <a href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a>
+        <div>
+          <a href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a>
+        </div>
       </form>
-    </div>
-    <div class="col-sm-6">
-      <p>{% blocktrans %}Don't forget:{% endblocktrans %}</p>
-      <ul>
-        <li>{% blocktrans %}Usernames and passwords are case-sensitive.{% endblocktrans %}</li>
-      </ul>
+
+      <p>
+        {% blocktrans %}
+        Don't forget:
+        Usernames and passwords are case-sensitive.
+        {% endblocktrans %}
+      </p>
       <p>{% blocktrans %}Need an account?{% endblocktrans %}</p>
       <p>
         <a class="btn btn-default" href="{{ register_url }}{% if next %}?next={{ next }}{% endif %}">

--- a/opendebates/templates/registration/login.html
+++ b/opendebates/templates/registration/login.html
@@ -18,7 +18,7 @@
         </div>
       </form>
 
-      <p>
+      <p class="small">
         {% blocktrans %}
         Don't forget:
         Usernames and passwords are case-sensitive.

--- a/opendebates/templates/registration/password_reset_form.html
+++ b/opendebates/templates/registration/password_reset_form.html
@@ -1,22 +1,25 @@
-{% extends "base.html" %}
+{% extends "registration/registration_base.html" %}
 {% load i18n %}
 
 {% block content %}
-<div class="flatpage">
-  
-<p>{% trans "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one." %}</p>
+<div class="flatpage row">
+  <div class="col-sm-8 col-sm-offset-2 text-center">
+    <p class="small">{% trans "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one." %}</p>
+    
+    <form action="" method="post">{% csrf_token %}
+      {{ form.email.errors }}
+      <p>
+        <label for="id_email">{% trans 'Email address:' %}</label> 
+        {% with request.GET.email|default:'' as default_email %}
+        <input class="form-control" id="id_email" maxlength="254" name="email" type="email" value="{{ form.cleaned_data.email|default:default_email }}">
+        {% endwith %}
 
-<form action="" method="post">{% csrf_token %}
-{{ form.email.errors }}
-<p>
-  <label for="id_email">{% trans 'Email address:' %}</label> 
-  {% with request.GET.email|default:'' as default_email %}
-  <input id="id_email" maxlength="254" name="email" type="email" value="{{ form.cleaned_data.email|default:default_email }}">
-  {% endwith %}
-  
-  <input type="submit" class="btn btn-default" 
-         value="{% trans 'Reset my password' %}" />
-</p>
-</form>
+        <br>
+        
+        <input type="submit" class="btn btn-primary" 
+               value="{% trans 'Reset my password' %}" />
+      </p>
+    </form>
+  </div>
 </div>
 {% endblock %}

--- a/opendebates/templates/registration/registration_base.html
+++ b/opendebates/templates/registration/registration_base.html
@@ -1,4 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load pipeline %}
 
+{% block loading_javascript %}
+foo
+{% javascript 'registration' %}
+{% endblock %}
 

--- a/opendebates/templates/registration/registration_form.html
+++ b/opendebates/templates/registration/registration_form.html
@@ -12,8 +12,8 @@
                type="submit" value="Create Account">
       </form>
 
-      <p>{% blocktrans %}Please note:{% endblocktrans %}</p>
-      <ul class="form-notes">
+      <p class="small">{% blocktrans %}Please note:{% endblocktrans %}</p>
+      <ul class="form-notes small">
         <li>{% blocktrans %}Usernames and passwords are case-sensitive.{% endblocktrans %}</li>
         <li>{% blocktrans %}All fields are required, except for Display Name and Twitter Handle.{% endblocktrans %}</li>
       </ul>

--- a/opendebates/templates/registration/registration_form.html
+++ b/opendebates/templates/registration/registration_form.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans "Register for an account" %}{% endblock %}
 {% block content %}
   <div class="row flatpage">
-    <div class="col-sm-6">
+    <div class="col-sm-8 col-sm-offset-2 text-center">
 
       <form method="post" action="">{% csrf_token %}
         {{ form|bootstrap }}
@@ -12,10 +12,8 @@
                type="submit" value="Create Account">
       </form>
 
-    </div>
-    <div class="col-sm-6">
       <p>{% blocktrans %}Please note:{% endblocktrans %}</p>
-      <ul>
+      <ul class="form-notes">
         <li>{% blocktrans %}Usernames and passwords are case-sensitive.{% endblocktrans %}</li>
         <li>{% blocktrans %}All fields are required, except for Display Name and Twitter Handle.{% endblocktrans %}</li>
       </ul>


### PR DESCRIPTION
* Center all text on login/register pages in a single column and shrink help text
* Use placeholders instead of labels (ugly javascript hack -- couldn't figure out a clean way to do it without scrapping django-bootstrap-form)
* Hide "Are you human?" label