### PR TITLE
Reinstate 'unmoderate' action for duplicates

### DIFF
--- a/opendebates/moderator_views.py
+++ b/opendebates/moderator_views.py
@@ -45,6 +45,13 @@ def merge(request):
 
     if request.POST.get("action").lower() == "reject":
         msg = _(u'No changes made and flag has been removed.')
+    elif request.POST.get("action").lower() == "unmoderate":
+        msg = _(u'Duplicate has been removed, and votes have not been merged.')
+        to_remove.approved = False
+        to_remove.duplicate_of = duplicate_of
+        to_remove.save()
+        if request.POST.get("send_email") == "yes":
+            send_email("your_idea_is_duplicate", {"idea": to_remove})
     elif request.POST.get("action").lower() == "merge":
         votes_already_cast = list(Vote.objects.filter(
             submission=duplicate_of).values_list("voter_id", flat=True))

--- a/opendebates/templates/opendebates/moderation/preview.html
+++ b/opendebates/templates/opendebates/moderation/preview.html
@@ -39,10 +39,11 @@
           <div>
             {% if duplicate_of %}
               <input type="hidden" name="duplicate_of" value="{{ duplicate_of.id }}">
-              <input type="submit" class="btn" name="action" value="Reject">
+              <input type="submit" class="btn btn-success" name="action" value="Reject">
+              <input type="submit" class="btn btn-warning" name="action" value="Unmoderate">
               <input type="submit" class="btn btn-danger" name="action" value="Merge">
             {% else %}
-              <input type="submit" class="btn" name="action" value="Keep">
+              <input type="submit" class="btn btn-success" name="action" value="Keep">
               <input type="submit" class="btn btn-danger" name="action" value="Remove">
             {% endif %}
           </div>

--- a/opendebates/tests/test_moderation.py
+++ b/opendebates/tests/test_moderation.py
@@ -239,10 +239,10 @@ class ModerationTest(TestCase):
 
         # Meanwhile the remaining submission has no direct record of the merge into it
         self.assertEqual(False, remaining.has_duplicates)
-        
+
         rsp = self.client.get(merged.get_absolute_url())
         self.assertEqual(NOT_FOUND, rsp.status_code)
-        
+
     def test_merge_link_hidden_after_merge(self):
         merge_url = reverse('merge', args=[self.first_submission.pk])
         rsp = self.client.get(self.first_submission.get_absolute_url())

--- a/opendebates/tests/test_moderation.py
+++ b/opendebates/tests/test_moderation.py
@@ -173,6 +173,76 @@ class ModerationTest(TestCase):
         self.assertEqual(1, Vote.objects.filter(
             voter=first_voter, submission=merged).count())
 
+    def test_unmoderate_does_not_merge_votes(self):
+        "During a duplicate unmoderate, no vote merging occurs"
+
+        self.client.logout()
+
+        first_voter = VoterFactory(user=None)
+        second_voter = VoterFactory(user=None)
+        third_voter = VoterFactory(user=None)
+
+        rsp = self.client.post(self.third_submission.get_absolute_url(), data={
+            'email': first_voter.email, 'zipcode': first_voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual("200", json.loads(rsp.content)['status'])
+
+        rsp = self.client.post(self.third_submission.get_absolute_url(), data={
+            'email': second_voter.email, 'zipcode': second_voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual("200", json.loads(rsp.content)['status'])
+
+        rsp = self.client.post(self.second_submission.get_absolute_url(), data={
+            'email': first_voter.email, 'zipcode': first_voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual("200", json.loads(rsp.content)['status'])
+
+        rsp = self.client.post(self.second_submission.get_absolute_url(), data={
+            'email': third_voter.email, 'zipcode': third_voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual("200", json.loads(rsp.content)['status'])
+
+        # Initially each submission's vote tally will include all votes that we just cast
+        # plus one for the submitter
+        self.assertEqual(Submission.objects.get(id=self.second_submission.id).votes, 3)
+        self.assertEqual(Submission.objects.get(id=self.third_submission.id).votes, 3)
+
+        assert self.client.login(username=self.user.username, password=self.password)
+        rsp = self.client.post(self.merge_url, data={
+            "action": "unmoderate",
+            "to_remove": self.third_submission.id,
+            "duplicate_of": self.second_submission.id,
+        })
+        self.assertRedirects(rsp, self.moderation_home_url)
+
+        merged = Submission.objects.get(id=self.third_submission.id)
+        remaining = Submission.objects.get(id=self.second_submission.id)
+
+        # Both ideas retain their original vote tallies
+        self.assertEqual(merged.votes, 3)
+        self.assertEqual(remaining.votes, 3)
+
+        # And vote objects are untouched
+        moved_vote = Vote.objects.get(voter=second_voter)
+        self.assertEqual(moved_vote.submission, merged)
+        self.assertEqual(moved_vote.original_merged_submission, None)
+        self.assertEqual(0, Vote.objects.filter(
+            voter=second_voter, submission=remaining).count())
+
+        # But the duplicate submission is now unavailable & has been marked as duplicate
+        self.assertEqual(False, merged.approved)
+        self.assertEqual(remaining, merged.duplicate_of)
+
+        # Meanwhile the remaining submission has no direct record of the merge into it
+        self.assertEqual(False, remaining.has_duplicates)
+        
+        rsp = self.client.get(merged.get_absolute_url())
+        self.assertEqual(NOT_FOUND, rsp.status_code)
+        
     def test_merge_link_hidden_after_merge(self):
         merge_url = reverse('merge', args=[self.first_submission.pk])
         rsp = self.client.get(self.first_submission.get_absolute_url())


### PR DESCRIPTION
At some point in the last sprint this feature seems to have gotten lost -- this PR reinstates it and adds a test to document its existence.  Unlike 'merge', the 'unmoderate' action will:
* Remove all record of the duplicate submission from the public site (i.e. mark approved=False)
* Not merge any votes
* Not display the merged submission in the remaining one, or mark the remaining one
  as having duplicates
* However it will still mark the merged submission with a pointer to what it was a duplicate of,
  for audit purposes.

This is important to retain since site policies may state that ideas with <N votes can be removed at any time without being merged.