### PR TITLE
Implement "local votes" tally for use in FL debate

### DIFF
--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -44,6 +44,7 @@ def global_vars(request):
         'ALLOW_SORTING_BY_VOTES': mode.allow_sorting_by_votes,
         'ALLOW_VOTING_AND_SUBMITTING_QUESTIONS': mode.allow_voting_and_submitting_questions,
         'DEBATE_TIME': mode.debate_time,
+        'LOCAL_VOTES_STATE': mode.debate_state,
         'SUBMISSION_CATEGORIES': SimpleLazyObject(_get_categories),
         'SITE_THEME_NAME': settings.SITE_THEME_NAME,
         'SITE_THEME': settings.SITE_THEMES[settings.SITE_THEME_NAME],

--- a/opendebates/migrations/0020_sitemode_debate_state.py
+++ b/opendebates/migrations/0020_sitemode_debate_state.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0019_sitemode'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='debate_state',
+            field=models.CharField(max_length=5, null=True, blank=True),
+        ),
+    ]

--- a/opendebates/migrations/0021_submission_local_votes.py
+++ b/opendebates/migrations/0021_submission_local_votes.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0020_sitemode_debate_state'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submission',
+            name='local_votes',
+            field=models.IntegerField(default=0, db_index=True),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -37,6 +37,7 @@ class SiteMode(CachingMixin, models.Model):
         default=datetime.datetime(2099, 1, 1),
         help_text="Enter time that debate starts in timezone %s" % settings.TIME_ZONE,
     )
+    debate_state = models.CharField(max_length=5, null=True, blank=True)
 
     objects = CachingManager()
 
@@ -73,6 +74,7 @@ class Submission(models.Model):
                                      related_name="duplicates")
 
     votes = models.IntegerField(default=0, db_index=True)
+    local_votes = models.IntegerField(default=0, db_index=True)
     score = models.FloatField(default=0, db_index=True)
     rank = models.FloatField(default=0, db_index=True)
 

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -81,6 +81,11 @@
           <option value="+votes" {% if sort == "+votes" %}selected{% endif %}>
             {% blocktrans %}Fewest Votes{% endblocktrans %}
           </option>
+          {% if LOCAL_VOTES_STATE %}
+          <option value="-local_votes" {% if sort == "+local_votes" %}selected{% endif %}>
+            {% blocktrans %}In-District Votes{% endblocktrans %}
+          </option>
+          {% endif %}
         {% endif %}
         </select>
         <div class="display-count">

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -129,6 +129,8 @@ def sort_list(citations_only, sort, ideas):
         ideas = ideas.order_by("-votes")
     elif sort == "+votes":
         ideas = ideas.order_by("votes")
+    elif sort == "-local_votes":
+        ideas = ideas.order_by("-local_votes")
 
     return ideas
 
@@ -151,3 +153,7 @@ def show_question_votes():
 
 def allow_voting_and_submitting_questions():
     return get_site_mode().allow_voting_and_submitting_questions
+
+
+def get_local_votes_state():
+    return get_site_mode().debate_state


### PR DESCRIPTION
* Add a knob on SiteMode to optionally set a state that should be considered local
* If that knob is set, then add a "Sort by local votes" option
  (as long as sorting by votes is enabled)
* Add a database field on submission table to tally local votes
* If the knob is set and the zipcode database has been loaded,
  then votes cast by any user or voter in the same state as the site
  will count towards the local vote tally