### PR TITLE
Make local vote sort option stick

### DIFF
--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -82,7 +82,7 @@
             {% blocktrans %}Fewest Votes{% endblocktrans %}
           </option>
           {% if LOCAL_VOTES_STATE %}
-          <option value="-local_votes" {% if sort == "+local_votes" %}selected{% endif %}>
+          <option value="-local_votes" {% if sort == "-local_votes" %}selected{% endif %}>
             {% blocktrans %}Most Florida Votes{% endblocktrans %}
           </option>
           {% endif %}


### PR DESCRIPTION
When selected once, we weren't keeping it selected, due
to a tiny typo in the template.