### PR TITLE
Check citation length before saving

### DIFF
--- a/opendebates/forms.py
+++ b/opendebates/forms.py
@@ -34,7 +34,7 @@ class QuestionForm(forms.Form):
     category = forms.ModelMultipleChoiceField(queryset=Category.objects.all())
     headline = forms.CharField(required=True)
     question = forms.CharField(required=False)
-    citation = forms.URLField(required=False)
+    citation = forms.URLField(required=False, max_length=255)
 
     def __init__(self, *args, **kwargs):
         super(QuestionForm, self).__init__(*args, **kwargs)

--- a/opendebates/tests/test_submission.py
+++ b/opendebates/tests/test_submission.py
@@ -68,6 +68,15 @@ class SubmissionTest(TestCase):
         self.assertIn('citation', form.errors)
         self.assertIn('Enter a valid URL.', str(form.errors))
 
+    def test_citation_too_long(self):
+        data = self.data.copy()
+        data['citation'] = 'https://www.' + 'x' * 250 + '.com'
+        rsp = self.client.post(self.url, data=data)
+        form = rsp.context['form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('citation', form.errors)
+        self.assertIn('has at most 255 characters', str(form.errors))
+
     # success
 
     def test_post_submission(self):


### PR DESCRIPTION
URLField models have a max_length of 255, but URLField form fields apparently don't check max_length.