### PR TITLE
Allow brief caching of /recent view

### DIFF
--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.http import Http404, HttpResponse, HttpResponseServerError, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
+from django.views.decorators.cache import cache_control
 from djangohelpers.lib import rendered_with, allow_http
 from registration.backends.simple.views import RegistrationView
 
@@ -67,6 +68,7 @@ def test(request):
     }
 
 
+@cache_control(max_age=5)  # Tell CF it can cache it, but only for 5 seconds.
 @allow_http("GET")
 @rendered_with("opendebates/snippets/recent_activity.html")
 def recent_activity(request):


### PR DESCRIPTION
Set max_age to 5 seconds. If we then remove
our page rule that told CF not to cache this view,
it should limit CF's caching to 5 seconds, but
allow us to serve a lot of cached copies of
the response in between.