### PR TITLE
Cache temp values longer

### DIFF
--- a/opendebates/tasks.py
+++ b/opendebates/tasks.py
@@ -68,10 +68,10 @@ def update_recent_events():
         entries = list(votes) + list(submissions)
         entries = sorted(entries, key=lambda x: x.created_at, reverse=True)[:10]
 
-        cache.set(RECENT_EVENTS_CACHE_ENTRY, entries, 300)
+        cache.set(RECENT_EVENTS_CACHE_ENTRY, entries, 24*3600)
 
         number_of_votes = Vote.objects.count()
-        cache.set(NUMBER_OF_VOTES_CACHE_ENTRY, number_of_votes, 300)
+        cache.set(NUMBER_OF_VOTES_CACHE_ENTRY, number_of_votes, 24*3600)
 
         logger.debug("There are %d entries" % len(entries))
         logger.debug("There are %d votes" % number_of_votes)

--- a/opendebates/tests/test_recent_events.py
+++ b/opendebates/tests/test_recent_events.py
@@ -20,10 +20,10 @@ class RecentEventsTest(TestCase):
         mock_cache.set.assert_any_call(
             RECENT_EVENTS_CACHE_ENTRY,
             [self.vote, self.vote.submission],
-            300
+            24*3600
         )
         num = Vote.objects.count()
-        mock_cache.set.assert_any_call(NUMBER_OF_VOTES_CACHE_ENTRY, num, 300)
+        mock_cache.set.assert_any_call(NUMBER_OF_VOTES_CACHE_ENTRY, num, 24*3600)
 
     def test_view_returns_events(self):
         mock_cache = mock.MagicMock()


### PR DESCRIPTION
When we compute things like the number of votes,
set its expiration in the cache to be much longer.
We want it to last at least through a full deploy,
however long that takes, because once the worker
is updated, it'll start putting its work into a
new cache "version" while all the unupgraded servers
will still be looking for it in the old cache version.
So that old cache version's entries need to continue
to be available as long as servers are looking for them.