### PR TITLE
Vary on additional parameters in cache keys for pagination and question fragments 

### DIFF
--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -56,6 +56,7 @@ def global_vars(request):
         'FACEBOOK_URL': FACEBOOK_URL,
         'TWITTER_URL': TWITTER_URL,
 
+        'SUBMISSIONS_PER_PAGE': settings.SUBMISSIONS_PER_PAGE,
         'SITE_DOMAIN': settings.SITE_DOMAIN,
         'SITE_LINK': settings.SITE_DOMAIN_WITH_PROTOCOL,
         'MIXPANEL_KEY': settings.MIXPANEL_KEY,

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -14,6 +14,8 @@ SITE_DOMAIN = os.environ.get("DOMAIN", os.environ.get("SITE_DOMAIN", "127.0.0.1:
 SITE_DOMAIN_WITH_PROTOCOL = "https://" + SITE_DOMAIN
 # Both DOMAIN variables are overwritten in local_settings.py
 
+SUBMISSIONS_PER_PAGE = 25
+
 SITE_THEMES = {
     'florida': {
         "HASHTAG": u"FLOpenDebate",

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -97,11 +97,11 @@
     {% endcache %}
     
   {% show_current_number as page_number %}
-  {% cache 30 idea_list search_term category.id sort page_number %}
+  {% cache 30 idea_list search_term category.id sort page_number request.GET.source %}
 
   <hr class="before-idea-list visible-xs" />
   <div class="row idea-list">
-    {% lazy_paginate 25 ideas %}
+    {% lazy_paginate SUBMISSIONS_PER_PAGE ideas %}
 
     {% for idea in ideas %}
       {% include "opendebates/snippets/idea.html" %}

--- a/opendebates/templates/opendebates/snippets/idea.html
+++ b/opendebates/templates/opendebates/snippets/idea.html
@@ -2,7 +2,7 @@
 {% load l10n %}
 {% load cache %}
 
-{% cache 30 question idea.id %}
+{% cache 30 question idea.id show_duplicates %}
 <div id="i{{ idea.id }}" data-idea-id="{{ idea.id }}" class="big-idea clearfix">
     <div class="votes col-md-3">
       {% if is_duplicate %}

--- a/opendebates/tests/test_pagination.py
+++ b/opendebates/tests/test_pagination.py
@@ -50,46 +50,46 @@ class PaginationTest(TestCase):
         self.assertEqual(['2'], qs.get('page'))
         self.assertEqual(3, len(qs.keys()))
 
+    @patch_cache_templatetag()
     def test_pagination_cache_does_not_share_source(self):
-        with patch_cache_templatetag():
-            rsp = self.client.get(self.url + '?source=foo&utm_medium=email')
-            link = self.find_first_page_link(rsp.content)
-            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
-            self.assertEqual(['foo'], qs.get('source'))
-            self.assertEqual(['email'], qs.get('utm_medium'))
-            self.assertEqual(['2'], qs.get('page'))
-            self.assertEqual(3, len(qs.keys()))
+        rsp = self.client.get(self.url + '?source=foo&utm_medium=email')
+        link = self.find_first_page_link(rsp.content)
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['foo'], qs.get('source'))
+        self.assertEqual(['email'], qs.get('utm_medium'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(3, len(qs.keys()))
 
-            # As long as a different ?source is used, the cache lookup for the pagination fragment
-            # should miss
-            rsp = self.client.get(self.url + '?source=bar&utm_medium=social')
-            link = self.find_first_page_link(rsp.content)
-            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
-            self.assertEqual(['bar'], qs.get('source'))
-            self.assertEqual(['social'], qs.get('utm_medium'))
-            self.assertEqual(['2'], qs.get('page'))
-            self.assertEqual(3, len(qs.keys()))
+        # As long as a different ?source is used, the cache lookup for the pagination fragment
+        # should miss
+        rsp = self.client.get(self.url + '?source=bar&utm_medium=social')
+        link = self.find_first_page_link(rsp.content)
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['bar'], qs.get('source'))
+        self.assertEqual(['social'], qs.get('utm_medium'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(3, len(qs.keys()))
 
+    @patch_cache_templatetag()
     def test_pagination_cache_shares_rest_of_query_string(self):
-        with patch_cache_templatetag():
-            rsp = self.client.get(self.url + '?source=foo&utm_medium=email&bar=fleem&baz=foo')
-            link = self.find_first_page_link(rsp.content)
-            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
-            self.assertEqual(['foo'], qs.get('source'))
-            self.assertEqual(['email'], qs.get('utm_medium'))
-            self.assertEqual(['fleem'], qs.get('bar'))
-            self.assertEqual(['foo'], qs.get('baz'))
-            self.assertEqual(['2'], qs.get('page'))
-            self.assertEqual(5, len(qs.keys()))
+        rsp = self.client.get(self.url + '?source=foo&utm_medium=email&bar=fleem&baz=foo')
+        link = self.find_first_page_link(rsp.content)
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['foo'], qs.get('source'))
+        self.assertEqual(['email'], qs.get('utm_medium'))
+        self.assertEqual(['fleem'], qs.get('bar'))
+        self.assertEqual(['foo'], qs.get('baz'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(5, len(qs.keys()))
 
-            # As long as the same ?source is used, the cache lookup for the pagination fragment
-            # should hit, even if that means serving links with someone else's query string
-            # parameters
-            rsp = self.client.get(self.url + '?source=foo&utm_medium=social&bar=morx')
-            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
-            self.assertEqual(['foo'], qs.get('source'))
-            self.assertEqual(['email'], qs.get('utm_medium'))
-            self.assertEqual(['fleem'], qs.get('bar'))
-            self.assertEqual(['foo'], qs.get('baz'))
-            self.assertEqual(['2'], qs.get('page'))
-            self.assertEqual(5, len(qs.keys()))
+        # As long as the same ?source is used, the cache lookup for the pagination fragment
+        # should hit, even if that means serving links with someone else's query string
+        # parameters
+        rsp = self.client.get(self.url + '?source=foo&utm_medium=social&bar=morx')
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['foo'], qs.get('source'))
+        self.assertEqual(['email'], qs.get('utm_medium'))
+        self.assertEqual(['fleem'], qs.get('bar'))
+        self.assertEqual(['foo'], qs.get('baz'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(5, len(qs.keys()))

--- a/opendebates/tests/test_pagination.py
+++ b/opendebates/tests/test_pagination.py
@@ -1,0 +1,95 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+import re
+import urlparse
+
+from .factories import SubmissionFactory
+from .utilities import patch_cache_templatetag
+
+
+@override_settings(SUBMISSIONS_PER_PAGE=1)
+class PaginationTest(TestCase):
+
+    def setUp(self):
+        self.url = reverse('list_ideas')
+
+        for i in range(2):
+            SubmissionFactory()
+
+    def find_first_page_link(self, content):
+        link = re.search('<a\W+href="(.*)"\W+rel="page"\W+class="endless_page_link">2</a>',
+                         content)
+        self.assertNotEqual(None, link)
+        return link.groups()[0]
+
+    def test_pagination_appears(self):
+        rsp = self.client.get(self.url)
+        self.assertIn('endless_page_link', rsp.content)
+        link = self.find_first_page_link(rsp.content)
+        self.assertEqual('/?page=2', link)
+
+    def test_pagination_preserves_querystring(self):
+        rsp = self.client.get(self.url + '?source=foo&utm_medium=email')
+        self.assertIn('endless_page_link', rsp.content)
+        link = self.find_first_page_link(rsp.content)
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['foo'], qs.get('source'))
+        self.assertEqual(['email'], qs.get('utm_medium'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(3, len(qs.keys()))
+
+    def test_pagination_drops_page_from_querystring(self):
+        rsp = self.client.get(self.url + '?page=1&source=foo&utm_medium=email')
+        self.assertIn('endless_page_link', rsp.content)
+        link = self.find_first_page_link(rsp.content)
+        qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+        self.assertEqual(['foo'], qs.get('source'))
+        self.assertEqual(['email'], qs.get('utm_medium'))
+        self.assertEqual(['2'], qs.get('page'))
+        self.assertEqual(3, len(qs.keys()))
+
+    def test_pagination_cache_does_not_share_source(self):
+        with patch_cache_templatetag():
+            rsp = self.client.get(self.url + '?source=foo&utm_medium=email')
+            link = self.find_first_page_link(rsp.content)
+            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+            self.assertEqual(['foo'], qs.get('source'))
+            self.assertEqual(['email'], qs.get('utm_medium'))
+            self.assertEqual(['2'], qs.get('page'))
+            self.assertEqual(3, len(qs.keys()))
+
+            # As long as a different ?source is used, the cache lookup for the pagination fragment
+            # should miss
+            rsp = self.client.get(self.url + '?source=bar&utm_medium=social')
+            link = self.find_first_page_link(rsp.content)
+            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+            self.assertEqual(['bar'], qs.get('source'))
+            self.assertEqual(['social'], qs.get('utm_medium'))
+            self.assertEqual(['2'], qs.get('page'))
+            self.assertEqual(3, len(qs.keys()))
+
+    def test_pagination_cache_shares_rest_of_query_string(self):
+        with patch_cache_templatetag():
+            rsp = self.client.get(self.url + '?source=foo&utm_medium=email&bar=fleem&baz=foo')
+            link = self.find_first_page_link(rsp.content)
+            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+            self.assertEqual(['foo'], qs.get('source'))
+            self.assertEqual(['email'], qs.get('utm_medium'))
+            self.assertEqual(['fleem'], qs.get('bar'))
+            self.assertEqual(['foo'], qs.get('baz'))
+            self.assertEqual(['2'], qs.get('page'))
+            self.assertEqual(5, len(qs.keys()))
+
+            # As long as the same ?source is used, the cache lookup for the pagination fragment
+            # should hit, even if that means serving links with someone else's query string
+            # parameters
+            rsp = self.client.get(self.url + '?source=foo&utm_medium=social&bar=morx')
+            qs = urlparse.parse_qs(urlparse.urlparse(link).query)
+            self.assertEqual(['foo'], qs.get('source'))
+            self.assertEqual(['email'], qs.get('utm_medium'))
+            self.assertEqual(['fleem'], qs.get('bar'))
+            self.assertEqual(['foo'], qs.get('baz'))
+            self.assertEqual(['2'], qs.get('page'))
+            self.assertEqual(5, len(qs.keys()))

--- a/opendebates/tests/utilities.py
+++ b/opendebates/tests/utilities.py
@@ -1,0 +1,27 @@
+from django.templatetags import cache as cache_tag
+
+from mock import patch
+
+
+class FakeNeverExpiringCacheNode(cache_tag.CacheNode):
+    def __init__(self, nodelist, expire_time_var, fragment_name, vary_on, cache_name):
+        self.nodelist = nodelist
+        self.expire_time_var = expire_time_var
+        self.fragment_name = fragment_name
+        self.vary_on = vary_on
+        self.cache_name = cache_name
+        self.fake_cache = {}
+
+    def render(self, context):
+        vary_on = [var.resolve(context) for var in self.vary_on]
+        cache_key = cache_tag.make_template_fragment_key(self.fragment_name, vary_on)
+
+        value = self.fake_cache.get(cache_key)
+        if value is None:
+            value = self.nodelist.render(context)
+            self.fake_cache[cache_key] = value
+        return value
+
+
+def patch_cache_templatetag():
+    return patch.object(cache_tag, 'CacheNode', FakeNeverExpiringCacheNode)


### PR DESCRIPTION
* Ensure that visitors don't end up with the wrong ?source after following pagination links from cache
* Ensure that visitors don't see merged duplicates when viewing list pages, and do see merged duplicates when viewing detail pages

(This isn't urgent or even necessary to deploy on the FL site since voting will be ending so soon anyway.  But it's been bugging me for days, and I finally figured out a way to write tests for it.)