### PR TITLE
Disable 'User Display Name' and 'Twitter Handle' features from the "testing" theme

### DIFF
--- a/opendebates/static/less/theme-testing.less
+++ b/opendebates/static/less/theme-testing.less
@@ -1,0 +1,5 @@
+.registration-page {
+  #id_display_name, #id_twitter_handle {
+    display: none;
+  }
+}


### PR DESCRIPTION
- Use CSS to hide these two fields from the registration form
- The existing site behavior defaults to displaying a user's first name and
  last initial when Display Name is not filled out, so that will always be
  the case here.
- The existing site behavior optionally tacks on a 'h/t @handle' to tweets
  about a question if its submitter has filled in a Twitter Handle, so that
  behavior will never be activated here.
