### PR TITLE
get environment creation working again in preparation for Fall 2016

### DIFF
--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -23,7 +23,6 @@
   database_user: dbuser
   home: /home/opendebates # no trailing /
   python: /usr/bin/python2.7
-  log_host:
 
 ## LOCAL / PROJECT SETTINGS ##
   disable_known_hosts: true
@@ -67,7 +66,7 @@
 # Local server port for pgbouncer
   pgbouncer_port: 5432
 
-  less_version: 2.5.3
+  less_version: 2.7.1
 
 # Local server ports used by Gunicorn (the Django apps server)
   server_ports:
@@ -160,11 +159,11 @@
       web: c4.xlarge
       worker: m4.large
     staging:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
+      cache: t2.micro
+      db-master: t2.small
+      db-slave: t2.small
+      web: t2.micro
+      worker: t2.micro
 
 # Mapping of Fabric environment names to AWS load balancer names.  Load
 # balancers can be configured in the AWS Management Console.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,6 @@ mccabe==0.3.1
 factory-boy==2.6.0
   fake-factory==0.5.3
 
-fabulaws==0.3.0a17
+fabulaws==0.3.0a27
 
 mock==1.3.0


### PR DESCRIPTION
- upgrade fabulaws (now more robust, will retry creation of failed instances)
- remove deprecated `log_host`
- updated less version (old version, 2.5.3, generates empty CSS files locally and on the servers)
- downsize instances for staging to avoid racking up a large bill
