### PR TITLE
Disable 'User Display Name' from the "testing" theme

### DIFF
--- a/opendebates/static/less/theme-testing.less
+++ b/opendebates/static/less/theme-testing.less
@@ -1,0 +1,5 @@
+.registration-page {
+  #id_display_name, #id_twitter_handle {
+    display: none;
+  }
+}

--- a/opendebates/static/less/theme-testing.less
+++ b/opendebates/static/less/theme-testing.less
@@ -1,5 +1,5 @@
 .registration-page {
-  #id_display_name, #id_twitter_handle {
+  #id_display_name {
     display: none;
   }
 }


### PR DESCRIPTION
- Use CSS to hide this field from the registration form
- The existing site behavior defaults to displaying a user's first name and
  last initial when Display Name is not filled out, so that will always be
  the case here.

NOTE: this trivial change probably be redone instead of merging my commit, because I did something noisy with git branches that I can't seem to fix.  :-)  So just submitting this PR for illustration, the gist is just "hide the user display name field from the registration form on the themes we will be deploying."
