### PR TITLE
add 'presidential' environment for Fall 2016 debates

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,6 +1,7 @@
 import logging
 # XXX import actual commands needed
 from fabulaws.library.wsgiautoscale.api import *  # noqa
+from fabulaws.library.wsgiautoscale.api import _setup_env
 
 root_logger = logging.getLogger()
 root_logger.addHandler(logging.StreamHandler())
@@ -11,3 +12,13 @@ fabulaws_logger.setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+@task
+def florida(deployment_tag=env.default_deployment, answer=None):
+    _setup_env(deployment_tag, 'florida')
+
+
+@task
+def presidential(deployment_tag=env.default_deployment, answer=None):
+    _setup_env(deployment_tag, 'presidential')

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,6 +24,7 @@ def presidential(deployment_tag=env.default_deployment, answer=None):
     _setup_env(deployment_tag, 'presidential')
 
 
+@task
 @roles('db-master')
 def pg_create_unaccent_ext():
     """

--- a/fabfile.py
+++ b/fabfile.py
@@ -11,3 +11,23 @@ fabulaws_logger.setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+@task
+@roles('db-master')
+def pg_create_unaccent_ext():
+    """
+    Workaround to facilitate granting the opendebates database user
+    permission to use the 'unaccent' extension in Postgres.
+    """
+    require('environment', provided_by=env.environments)
+    sudo('sudo -u postgres psql %s -c "CREATE EXTENSION IF NOT EXISTS unaccent;"'
+         '' % env.database_name)
+    for func in [
+        'unaccent(text)',
+        'unaccent(regdictionary, text)',
+        'unaccent_init(internal)',
+        'unaccent_lexize(internal, internal, internal, internal)',
+    ]:
+        sudo('sudo -u postgres psql %s -c "ALTER FUNCTION %s OWNER TO %s;"'
+             '' % (env.database_name, func, env.database_user))

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -20,7 +20,7 @@
   deploy_user: opendebates
   webserver_user: opendebates-web
   database_host: localhost
-  database_user: dbuser
+  database_user: opendebates
   home: /home/opendebates # no trailing /
   python: /usr/bin/python2.7
 
@@ -161,11 +161,11 @@
       web: c4.xlarge
       worker: m4.large
     presidential:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
+      cache: t2.micro
+      db-master: t2.small
+      db-slave: t2.small
+      web: t2.micro
+      worker: t2.micro
 
 # Mapping of Fabric environment names to AWS load balancer names.  Load
 # balancers can be configured in the AWS Management Console.

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -1,7 +1,7 @@
   # "testing": demopenquestions
-  # "florida" floridaopendebate
-  # "production": UNUSED
   # "staging": staging
+  # "florida" floridaopendebate
+  # "presidential": presidentialopenquestions
 
   instance_settings:
     # http://uec-images.ubuntu.com/releases/trusty/release/
@@ -51,17 +51,18 @@
 # that should be deployed.
   branches:
     opendebates:
-      production: master
-      florida: master
-      staging: develop
       testing: master
+      staging: develop
+      florida: master
+      presidential: master
 
 ## SERVER SETTINGS ##
   use_basic_auth:
-    florida: False
-    # "testing" is the upcoming production site, hide it until ready to unveil
     testing: True
-    staging: False
+    staging: True
+    florida: False
+    # "presidential" is the upcoming production site, hide it until ready to unveil
+    presidential: True
 
 # Local server port for pgbouncer
   pgbouncer_port: 5432
@@ -70,10 +71,10 @@
 
 # Local server ports used by Gunicorn (the Django apps server)
   server_ports:
-    staging: 8000
-    production: 8001
-    testing: 8002
-    florida: 8003
+    testing: 8000
+    staging: 8001
+    florida: 8002
+    presidential: 8003
 
 
 # Whether we're hosting static files on our webservers ('local')
@@ -93,18 +94,19 @@
 # is used to update a Site object in the database.
 # Wildcard format used per ALLOWED_HOSTS setting
   site_domains_map:
-    production:
-    -
-    florida:
-    - floridaopendebate.com
-    - www.floridaopendebate.com
-    staging:
-    - staging.demopenquestions.com
     testing:
     - demopenquestions.com
     - testing.demopenquestions.com
     - opendebates-testing-lb-476601241.us-east-1.elb.amazonaws.com
     - www.demopenquestions.com
+    staging:
+    - staging.demopenquestions.com
+    florida:
+    - floridaopendebate.com
+    - www.floridaopendebate.com
+    presidential:
+    - presidentialopenquestions.com
+    - www.presidentialopenquestions.com
 
 ## ENVIRONMENT / ROLE SETTINGS ##
 
@@ -112,10 +114,10 @@
   deployments:
   - opendebates
   environments:
-  - staging
-  - production
-  - florida
   - testing
+  - staging
+  - florida
+  - presidential
   valid_roles:
   - cache
   - db-master
@@ -140,18 +142,6 @@
 
 # Mapping of environment and role to EC2 instance types (sizes)
   instance_types:
-    production:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
-    florida:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
     testing:
       cache: c4.large
       db-master: m4.2xlarge
@@ -164,43 +154,43 @@
       db-slave: t2.small
       web: t2.micro
       worker: t2.micro
+    florida:
+      cache: c4.large
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c4.xlarge
+      worker: m4.large
+    presidential:
+      cache: c4.large
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c4.xlarge
+      worker: m4.large
 
 # Mapping of Fabric environment names to AWS load balancer names.  Load
 # balancers can be configured in the AWS Management Console.
   load_balancers:
     opendebates:
-      production:
-      - opendebates-production-lb
-      florida:
-      - opendebates-florida-lb
-      staging:
-      - opendebates-staging-lb
       testing:
       - opendebates-testing-lb
+      staging:
+      - opendebates-staging-lb
+      florida:
+      - opendebates-florida-lb
+      presidential:
+      - opendebates-presidential-lb
 
 # Mapping of Fabric environment names to AWS auto scaling group names. Auto
 # scaling groups can be configured in the AWS Management Console.
   auto_scaling_groups:
     opendebates:
-      production: opendebates-production-ag
-      florida: opendebates-florida-ag
-      staging: opendebates-staging-ag
       testing: opendebates-testing-ag
+      staging: opendebates-staging-ag
+      florida: opendebates-florida-ag
+      presidential: opendebates-presidential-ag
 
 # Mapping of Fabric environment and role to Elastic Block Device sizes (in GB)
   volume_sizes:
-    production:
-      cache: 10
-      db-master: 250
-      db-slave: 250
-      web: 30
-      worker: 50
-    florida:
-      cache: 10
-      db-master: 250
-      db-slave: 250
-      web: 30
-      worker: 50
     testing:
       cache: 10
       db-master: 250
@@ -212,6 +202,18 @@
       db-master: 100
       db-slave: 100
       web: 10
+      worker: 50
+    florida:
+      cache: 10
+      db-master: 250
+      db-slave: 250
+      web: 30
+      worker: 50
+    presidential:
+      cache: 10
+      db-master: 250
+      db-slave: 250
+      web: 30
       worker: 50
 
 # Mapping of Fabric environment and role to Elastic Block Device volume types

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -118,6 +118,9 @@
   - staging
   - florida
   - presidential
+  production_environments:
+  - florida
+  - presidenetial
   valid_roles:
   - cache
   - db-master

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -54,7 +54,7 @@
       testing: master
       staging: develop
       florida: master
-      presidential: master
+      presidential: develop # XXX change to master for final prod deploy 9/14/16
 
 ## SERVER SETTINGS ##
   use_basic_auth:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,6 @@ mccabe==0.3.1
 factory-boy==2.6.0
   fake-factory==0.5.3
 
-fabulaws==0.3.0a27
+fabulaws==0.3.0a28
 
 mock==1.3.0


### PR DESCRIPTION
- I opted to stick with the event-specific naming for environments
- This depends on (includes) PR #186, which should be merged first
- I reordered the environments so they appear in this order throughout the file: testing, staging, florida, presidential
- I moved the opendebates-specific environments out of fabulaws and into our `fabfile.py`
- The servers use small instances sizes for now (I'll bump these up next week)
