### PR TITLE
Allow admins to customize header text and after-submission popup text

### DIFF
--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -76,6 +76,10 @@ def global_vars(request):
                re.match(mode.announcement_page_regex, request.path))
               ) else None,
 
+        'BANNER_HEADER_TITLE': mode.banner_header_title,
+        'BANNER_HEADER_COPY': mode.banner_header_copy,
+        'POPUP_AFTER_SUBMISSION_TEXT': json.dumps(mode.popup_after_submission_text),
+
         'SUBMISSION_CATEGORIES': SimpleLazyObject(_get_categories),
         'SITE_THEME_NAME': settings.SITE_THEME_NAME,
         'SITE_THEME': settings.SITE_THEMES[settings.SITE_THEME_NAME],

--- a/opendebates/migrations/0024_auto_20160909_1025.py
+++ b/opendebates/migrations/0024_auto_20160909_1025.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0023_sitemode_announcement_page_regex'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='banner_header_copy',
+            field=models.TextField(default='Ask about the issues that are most important to you -- then vote for other important questions and encourage friends to do the same!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='banner_header_title',
+            field=models.TextField(default='Welcome to the<br>Open Debate'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='popup_after_submission_text',
+            field=models.TextField(default='Next, help your question collect votes. Share it on social media and email it to friends.'),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -45,6 +45,16 @@ class SiteMode(CachingMixin, models.Model):
     announcement_link = models.URLField(null=True, blank=True)
     announcement_page_regex = models.CharField(max_length=255, null=True, blank=True)
 
+    banner_header_title = models.TextField(default=u'Welcome to the<br>Open Debate')
+    banner_header_copy = models.TextField(default=u'Ask about the issues that are most '
+                                          'important to you -- then vote for other '
+                                          'important questions and encourage friends '
+                                          'to do the same!')
+
+    popup_after_submission_text = models.TextField(default=u'Next, help your question '
+                                                   'collect votes. Share it on social '
+                                                   'media and email it to friends.')
+
     objects = CachingManager()
 
 

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -19,13 +19,6 @@ SUBMISSIONS_PER_PAGE = 25
 SITE_THEMES = {
     'florida': {
         "HASHTAG": u"FLOpenDebate",
-        "HEADER_TITLE": _(u"WELCOME TO THE\nFLORIDA OPEN DEBATE"),
-        "HEADER_COPY": _(
-            u"Ask Congressman David Jolly (R-FL) and Congressman Alan Grayson (D-FL) about "
-            u"the issues that are most important "
-            "to you -- then vote and tell others! Watch the Florida Open Debate for U.S. "
-            "Senate right here on Monday, April 25, at 7:00 pm EDT. All questions "
-            "will be chosen from among those that receive the most votes online."),
         "TWITTER_IMAGE":
             "https://s3.amazonaws.com/s3.boldprogressives.org/images/"
             "OpenDebates_VOTE-NOW_TW-1024x512-FODUrl.png",
@@ -86,12 +79,6 @@ SITE_THEMES = {
     },
     'testing': {  # Presidential Debate
         "HASHTAG": "DemOpenForum",
-        "HEADER_TITLE": _("WELCOME TO THE\nDEMOCRATIC OPEN FORUM"),
-        "HEADER_COPY": _(
-            u"Ask Bernie Sanders and Hillary Clinton about the issues that are most important "
-            "to you -- then vote and tell others! Watch the Democratic Open Forum on CNN "
-            "or right here on Monday, April 25, at 8:00 pm EDT. All questions will be chosen from "
-            "among those that receive the most votes online."),
 
         # FIXME: Twitter & Facebook settings for Presidential debate
         "TWITTER_IMAGE":

--- a/opendebates/static/js/base/helpers.js
+++ b/opendebates/static/js/base/helpers.js
@@ -293,7 +293,8 @@
     if (window.location.hash && window.location.hash.match(/created=(\d+)/)) {
       var ideaId = window.location.hash.match(/created=(\d+)/)[1];
       var el = $(window.Handlebars.templates.after_question_submitted_modal({
-        "static": ODebates.paths.static
+        "static": ODebates.paths.static,
+        "strings": ODebates.strings
       }));
       el.find(".social-links-container .social-links").html(
         $(".big-idea[data-idea-id="+ideaId+"] .social-links").html());

--- a/opendebates/static/templates/base/after_question_submitted_modal.handlebars
+++ b/opendebates/static/templates/base/after_question_submitted_modal.handlebars
@@ -11,10 +11,7 @@
           <h2>Thank You for Submitting a&nbsp;Question</h2>
         </div>
         <p>
-          Next, help your question collect votes. Share it on social media
-          and email it to friends. For the live event, all questions will be
-          chosen from among the Top 30 that received the most votes (and no
-          more than the Top 5 in each category).
+          {{{strings.afterQuestionSubmittedText}}}
         </p>
 
         <div class="social-links-container">

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -70,8 +70,8 @@
       {% endif %}
     </div>
     <div class="header-title">
-      <h1><a href="/">{{ SITE_THEME.HEADER_TITLE|linebreaks }}</a></h1>
-      <div class="header-copy">{{ SITE_THEME.HEADER_COPY }}</div>
+      <h1><a href="/">{{ BANNER_HEADER_TITLE|safe }}</a></h1>
+      <div class="header-copy">{{ BANNER_HEADER_COPY|safe }}</div>
       <div class="header-small-logos">
         <img src="{% static "images/logo-header-partner-1.png" %}">
         <img src="{% static "images/logo-header-partner-2.png" %}">
@@ -141,6 +141,9 @@
   ODebates.paths.merge = "{% url 'merge' 0 %}";
   ODebates.paths.login = "{% url 'auth_login' %}";
   ODebates.paths.register = "{% url 'registration_register' %}";
+
+  ODebates.strings = ODebates.strings || {};
+  ODebates.strings.afterQuestionSubmittedText = {{ POPUP_AFTER_SUBMISSION_TEXT|safe }};
 
   {% if DEBUG %}
     ODebates.configs.debug = true;


### PR DESCRIPTION
- Remove header title and text from settings.SITE_THEME object
- Add header title, header text, and popup text to SiteMode
- Mark all three safe, so admins can use HTML styling, line breaks, etc
- Start an ODebates.strings javascript object for text in .js and .hbars
- Pass the popup text through json.dumps to make sure we're escaping quotes
  before putting it in our inline Javascript
