### PR TITLE
Allow removal of user Display Name feature with a setting

### DIFF
--- a/opendebates/forms.py
+++ b/opendebates/forms.py
@@ -1,6 +1,7 @@
 from urlparse import urlparse
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.urlresolvers import resolve, Resolver404
@@ -60,9 +61,12 @@ class OpenDebatesRegistrationForm(RegistrationForm):
 
     first_name = forms.CharField(max_length=30)
     last_name = forms.CharField(max_length=30)
-    display_name = forms.CharField(max_length=255,
-                                   label=mark_safe(display_name_label),
-                                   required=False)
+
+    if settings.ENABLE_USER_DISPLAY_NAME:
+        display_name = forms.CharField(max_length=255,
+                                       label=mark_safe(display_name_label),
+                                       required=False)
+
     twitter_handle = forms.CharField(max_length=255,
                                      label=mark_safe(twitter_handle_label),
                                      required=False)

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -141,6 +141,8 @@ SITE_THEME_NAME = 'florida'
 SITE_THEME = SITE_THEMES[SITE_THEME_NAME]
 # SITE_THEME_NAME and SITE_THEME get overriden in local_settings
 
+ENABLE_USER_DISPLAY_NAME = False
+
 # SECRET_KEY is overriden in deploy settings
 SECRET_KEY = 'secret-key-for-local-use-only'
 


### PR DESCRIPTION
By default, Display Name is now disabled.  It can be reenabled for a deployment with `ENABLE_USER_DISPLAY_NAME = True` in `local_settings.py`

@tobiasmcnulty You asked: "I'm thinking SiteMode could eventually be used for some form of multitenancy -- do you agree and if so would it make sense to put it there?"

I agree about SiteMode + multitenancy in the longer term, but I'm tentatively thinking this still belongs as a deployment-wide setting.  The most likely multi-debate hosting model we'd want would be "separate questions + votes + categories, but shared users + profiles."  So I think toggling any user-level features across debates on a single installation would complicate that.

The cases where I think we'd still want to reenable the display name would be at a somewhat different level -- e.g. if someone else is administering the debate entirely, or if we're using the code for a very different type of event like http://thinkbig.us/ -- where I think it will probably end up being easier to have an entirely separate installation anyway.
