### PR TITLE
move remaining "theme" settings from settings.py dictionary to SiteMode model

### DIFF
--- a/deployment/templates/local_settings.py
+++ b/deployment/templates/local_settings.py
@@ -196,10 +196,5 @@ USE_CAPTCHA = {{ use_captcha|default(true) }}
 MIXPANEL_KEY = '{{ mixpanel_key }}'
 OPTIMIZELY_KEY = '{{ optimizely_key }}'
 
-if '{{ environment }}' in SITE_THEMES:
-    SITE_THEME_NAME = '{{ environment }}'
-else:
-    SITE_THEME_NAME = 'testing'
-SITE_THEME = SITE_THEMES[SITE_THEME_NAME]
 SITE_DOMAIN = '{{ site_domains[0] }}'
 SITE_DOMAIN_WITH_PROTOCOL = "https://" + SITE_DOMAIN

--- a/deployment/templates/local_settings.py
+++ b/deployment/templates/local_settings.py
@@ -196,5 +196,9 @@ USE_CAPTCHA = {{ use_captcha|default(true) }}
 MIXPANEL_KEY = '{{ mixpanel_key }}'
 OPTIMIZELY_KEY = '{{ optimizely_key }}'
 
+if '{{ environment }}' in SITE_THEMES:
+    SITE_THEME_NAME = '{{ environment }}'
+else:
+    SITE_THEME_NAME = 'testing'
 SITE_DOMAIN = '{{ site_domains[0] }}'
 SITE_DOMAIN_WITH_PROTOCOL = "https://" + SITE_DOMAIN

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -1,3 +1,5 @@
+import itertools
+
 from django.contrib.admin import ModelAdmin, register
 from djangohelpers.export_action import admin_list_export
 
@@ -48,3 +50,34 @@ class FlagAdmin(ModelAdmin):
 class SiteModeAdmin(ModelAdmin):
     list_display = ['debate_time', 'show_question_votes', 'show_total_votes',
                     'allow_sorting_by_votes']
+    _fields = [f.name for f in models.SiteMode._meta.get_fields() if f.name != 'id']
+    fieldsets = [
+        ('General Settings', {
+            'fields': ['show_question_votes', 'show_total_votes', 'allow_sorting_by_votes',
+                       'allow_voting_and_submitting_questions']
+        }),
+        ('Debate Details', {
+            'fields': [f for f in _fields if f.startswith('debate_')],
+        }),
+        ('Announcement Details', {
+            'fields': [f for f in _fields if f.startswith('announcement_')],
+        }),
+        ('Site Content', {
+            'fields': ['hashtag', 'banner_header_title', 'banner_header_copy',
+                       'popup_after_submission_text'],
+        }),
+        ('Email Sharing Defaults', {
+            'fields': [f for f in _fields if f.startswith('email_')],
+        }),
+        ('Facebook Sharing Defaults', {
+            'fields': [f for f in _fields if f.startswith('facebook_')],
+        }),
+        ('Twitter Sharing Defaults', {
+            'fields': [f for f in _fields if f.startswith('twitter_')],
+        }),
+    ]
+    _used_fields = [fieldset[1]['fields'] for fieldset in fieldsets]
+    _used_fields = set(itertools.chain.from_iterable(_used_fields))
+    _missed_fields = set(_fields) - _used_fields
+    if _missed_fields:
+        fieldsets.append(('Other', {'fields': sorted(list(_missed_fields))}))

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -66,14 +66,29 @@ class SiteModeAdmin(ModelAdmin):
             'fields': ['hashtag', 'banner_header_title', 'banner_header_copy',
                        'popup_after_submission_text'],
         }),
-        ('Email Sharing Defaults', {
+        ('Email Share', {
             'fields': [f for f in _fields if f.startswith('email_')],
         }),
-        ('Facebook Sharing Defaults', {
-            'fields': [f for f in _fields if f.startswith('facebook_')],
+        ('Facebook Meta Data', {
+            'fields': ['facebook_image'],
         }),
-        ('Twitter Sharing Defaults', {
-            'fields': [f for f in _fields if f.startswith('twitter_')],
+        ('Facebook Share of the Whole Site', {
+            'fields': ['facebook_site_title', 'facebook_site_description'],
+        }),
+        ('Facebook Share of Individual Questions', {
+            'fields': ['facebook_question_title', 'facebook_question_description'],
+        }),
+        ('Twitter Meta Data', {
+            'fields': ['twitter_image', 'twitter_site_description',
+                       'twitter_question_description'],
+        }),
+        ('Twitter Share of the Whole Site', {
+            'fields': ['twitter_site_title', 'twitter_site_text'],
+        }),
+        ('Twitter Share of Individual Questions', {
+            'fields': ['twitter_question_title',
+                       'twitter_question_text_with_handle',
+                       'twitter_question_text_no_handle'],
         }),
     ]
     _used_fields = [fieldset[1]['fields'] for fieldset in fieldsets]

--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -10,18 +10,6 @@ from .models import Category, Vote
 from .utils import get_voter, get_number_of_votes, vote_needs_captcha, get_site_mode
 
 
-url_tmpl = u"https://twitter.com/intent/tweet?url=" + \
-                   "%(SITE_DOMAIN)s&text=%(tweet_text)s"
-TWITTER_URL = url_tmpl % {
-            "SITE_DOMAIN": quote_plus(settings.SITE_DOMAIN_WITH_PROTOCOL + "?source=tw-site"),
-            "tweet_text": quote_plus(settings.SITE_THEME['TWITTER_SITE_TEXT']),
-            }
-
-FACEBOOK_URL = u"https://www.facebook.com/sharer/sharer.php?&u=%(url)s" % {
-            "url": quote_plus(settings.SITE_DOMAIN_WITH_PROTOCOL + "?source=fb-site"),
-            }
-
-
 def voter(request):
     def _get_voter():
         return get_voter(request)
@@ -45,6 +33,15 @@ def global_vars(request):
         return Category.objects.all()
 
     mode = get_site_mode()
+
+    url_tmpl = u"https://twitter.com/intent/tweet?url=%(SITE_DOMAIN)s&text=%(tweet_text)s"
+    TWITTER_URL = url_tmpl % {
+        "SITE_DOMAIN": quote_plus(settings.SITE_DOMAIN_WITH_PROTOCOL + "?source=tw-site"),
+        "tweet_text": quote_plus(mode.twitter_site_text),
+    }
+    FACEBOOK_URL = u"https://www.facebook.com/sharer/sharer.php?&u=%(url)s" % {
+        "url": quote_plus(settings.SITE_DOMAIN_WITH_PROTOCOL + "?source=fb-site"),
+    }
 
     return {
         'CAPTCHA_SITE_KEY': settings.NORECAPTCHA_SITE_KEY,
@@ -85,5 +82,5 @@ def global_vars(request):
 
         'SUBMISSION_CATEGORIES': SimpleLazyObject(_get_categories),
         'SITE_THEME_NAME': settings.SITE_THEME_NAME,
-        'SITE_THEME': settings.SITE_THEMES[settings.SITE_THEME_NAME],
+        'SITE_MODE': mode,
     }

--- a/opendebates/migrations/0025_move_site_theme_to_site_mode.py
+++ b/opendebates/migrations/0025_move_site_theme_to_site_mode.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='sitemode',
             name='facebook_question_title',
-            field=models.TextField(default='Click here to vote on this question for U.S. Senate candidates to answer at the #OpenDebate in [STATE!'),
+            field=models.TextField(default='Click here to vote on this question for U.S. Senate candidates to answer at the #OpenDebate in [STATE]!'),
         ),
         migrations.AddField(
             model_name='sitemode',

--- a/opendebates/migrations/0025_move_site_theme_to_site_mode.py
+++ b/opendebates/migrations/0025_move_site_theme_to_site_mode.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0024_auto_20160909_1025'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='email_body',
+            field=models.TextField(default=b'Vote for my progressive idea for @OpenDebaters %(url)s'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='email_subject',
+            field=models.CharField(default=b'Vote for my progressive idea for @OpenDebaters', max_length=998),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='facebook_image',
+            field=models.URLField(default=b'https://s3.amazonaws.com/s3.boldprogressives.org/images/OpenDebates_VOTE-NOW_FB-1200x717-FODUrl.png'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='facebook_question_description',
+            field=models.TextField(default='"{idea}" At [TIME] on [DATE], [CANDIDATES] answer top vote-getting questions at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive Change Institute'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='facebook_question_title',
+            field=models.TextField(default='Click here to vote on this question for U.S. Senate candidates to answer at the #OpenDebate in [STATE!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='facebook_site_description',
+            field=models.TextField(default='Groundbreaking bottom-up #OpenDebate to take place [DATE] @[TIME], hosted by Open Debate Coalition, Progressive Change Institute, & [MEDIA PARTNER]. All questions will be chosen from top vote-getters online. Submit & vote here!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='facebook_site_title',
+            field=models.TextField(default='HISTORIC: [CANDIDATES] answer YOUR top-voted questions!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='hashtag',
+            field=models.CharField(default=b'DemOpenForum', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_image',
+            field=models.URLField(default=b'https://s3.amazonaws.com/s3.boldprogressives.org/images/OpenDebates_VOTE-NOW_TW-1024x512-FODUrl.png'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_question_description',
+            field=models.TextField(default='"{idea}" At [TIME] on [DAY, [CANDIDATES] answer top vote-getting questions at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive Change Institute'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_question_text',
+            field=models.TextField(default='Submit & vote on questions for #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst.'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_question_title',
+            field=models.TextField(default='Click here to vote on this question for U.S. Senate candidates to answer at the #OpenDebate in Florida!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_site_description',
+            field=models.TextField(default='[DATE] [TIME] on [TBD]: Voters set the agenda for groundbreaking #OpenDebate. Submit & vote here!'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_site_text',
+            field=models.TextField(default='Submit & vote on questions for the #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst.'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_site_title',
+            field=models.TextField(default='U.S. Senate candidates answer YOUR questions!'),
+        ),
+    ]

--- a/opendebates/migrations/0025_move_site_theme_to_site_mode.py
+++ b/opendebates/migrations/0025_move_site_theme_to_site_mode.py
@@ -63,7 +63,12 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='sitemode',
-            name='twitter_question_text',
+            name='twitter_question_text_with_handle',
+            field=models.TextField(default='Submit & vote on questions for #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst.'),
+        ),
+        migrations.AddField(
+            model_name='sitemode',
+            name='twitter_question_text_no_handle',
             field=models.TextField(default='Submit & vote on questions for #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst.'),
         ),
         migrations.AddField(

--- a/opendebates/migrations/0025_move_site_theme_to_site_mode.py
+++ b/opendebates/migrations/0025_move_site_theme_to_site_mode.py
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='sitemode',
             name='twitter_question_text_with_handle',
-            field=models.TextField(default='Submit & vote on questions for #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst.'),
+            field=models.TextField(default='Submit & vote on questions for #OpenDebate hosted by Open Debate Coalition, Progressive Change Inst. h/t @{handle}'),
         ),
         migrations.AddField(
             model_name='sitemode',

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -71,9 +71,11 @@ class SiteMode(CachingMixin, models.Model):
         default=site_defaults.TWITTER_QUESTION_DESCRIPTION,
     )
     twitter_question_text_with_handle = models.TextField(
-        default=site_defaults.TWITTER_QUESTION_TEXT,
+        default=site_defaults.TWITTER_QUESTION_TEXT_WITH_HANDLE,
     )
-    twitter_question_text_no_handle = models.TextField(default=site_defaults.TWITTER_QUESTION_TEXT)
+    twitter_question_text_no_handle = models.TextField(
+        default=site_defaults.TWITTER_QUESTION_TEXT_NO_HANDLE,
+    )
     twitter_question_title = models.TextField(default=site_defaults.TWITTER_QUESTION_TITLE)
     twitter_site_description = models.TextField(default=site_defaults.TWITTER_SITE_DESCRIPTION)
     twitter_site_text = models.TextField(default=site_defaults.TWITTER_SITE_TEXT)
@@ -171,8 +173,9 @@ class Submission(CachedSiteModeMixin, models.Model):
 
     def tweet_text(self):
         if self.voter.twitter_handle:
-            text = self.site_mode.twitter_question_text_with_handle
-            text += u" h/t @%s" % self.voter.twitter_handle
+            text = self.site_mode.twitter_question_text_with_handle.format(
+                handle=self.voter.twitter_handle,
+            )
         else:
             text = self.site_mode.twitter_question_text_no_handle
         return text

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -84,12 +84,16 @@ class SiteMode(CachingMixin, models.Model):
 
 class CachedSiteModeMixin(object):
 
+    def _get_site_mode(self):
+        # extracted in its own method for testing purposes
+        from opendebates.utils import get_site_mode
+        return get_site_mode()
+
     @property
     def site_mode(self):
         # avoid lots of unneeded round trips to memcached in production
         if not hasattr(self, '_cached_site_mode'):
-            from opendebates.utils import get_site_mode
-            self._cached_site_mode = get_site_mode()
+            self._cached_site_mode = self._get_site_mode()
         return self._cached_site_mode
 
 

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -164,13 +164,6 @@ class Submission(CachedSiteModeMixin, models.Model):
     def get_absolute_url(self):
         return "vote", [self.id]
 
-    def my_tweet_text(self):
-        params = {
-            "hashtag": self.site_mode.hashtag,
-        }
-        return _(u"Vote for my progressive idea for @ThinkBigUS #%s(hashtag)s. "
-                 "30 leaders in Congress will see top ideas!" % params)
-
     def tweet_text(self):
         if self.voter.twitter_handle:
             text = self.site_mode.twitter_question_text_with_handle.format(

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -52,7 +52,7 @@ class SiteMode(CachingMixin, models.Model):
     banner_header_copy = models.TextField(default=site_defaults.BANNER_HEADER_COPY)
 
     popup_after_submission_text = models.TextField(
-        default=site_defaults.POPUP_AFTER_SUBMISSION_TEXT
+        default=site_defaults.POPUP_AFTER_SUBMISSION_TEXT,
     )
 
     email_subject = models.CharField(default=site_defaults.EMAIL_SUBJECT, max_length=998)
@@ -60,7 +60,7 @@ class SiteMode(CachingMixin, models.Model):
 
     facebook_image = models.URLField(default=site_defaults.FACEBOOK_IMAGE)
     facebook_question_description = models.TextField(
-        default=site_defaults.FACEBOOK_QUESTION_DESCRIPTION
+        default=site_defaults.FACEBOOK_QUESTION_DESCRIPTION,
     )
     facebook_question_title = models.TextField(default=site_defaults.FACEBOOK_QUESTION_TITLE)
     facebook_site_description = models.TextField(default=site_defaults.FACEBOOK_SITE_DESCRIPTION)
@@ -68,9 +68,12 @@ class SiteMode(CachingMixin, models.Model):
 
     twitter_image = models.URLField(default=site_defaults.TWITTER_IMAGE)
     twitter_question_description = models.TextField(
-        default=site_defaults.TWITTER_QUESTION_DESCRIPTION
+        default=site_defaults.TWITTER_QUESTION_DESCRIPTION,
     )
-    twitter_question_text = models.TextField(default=site_defaults.TWITTER_QUESTION_TEXT)
+    twitter_question_text_with_handle = models.TextField(
+        default=site_defaults.TWITTER_QUESTION_TEXT,
+    )
+    twitter_question_text_no_handle = models.TextField(default=site_defaults.TWITTER_QUESTION_TEXT)
     twitter_question_title = models.TextField(default=site_defaults.TWITTER_QUESTION_TITLE)
     twitter_site_description = models.TextField(default=site_defaults.TWITTER_SITE_DESCRIPTION)
     twitter_site_text = models.TextField(default=site_defaults.TWITTER_SITE_TEXT)
@@ -163,9 +166,11 @@ class Submission(CachedSiteModeMixin, models.Model):
                  "30 leaders in Congress will see top ideas!" % params)
 
     def tweet_text(self):
-        text = self.site_mode.twitter_question_text
         if self.voter.twitter_handle:
+            text = self.site_mode.twitter_question_text_with_handle
             text += u" h/t @%s" % self.voter.twitter_handle
+        else:
+            text = self.site_mode.twitter_question_text_no_handle
         return text
 
     def facebook_text(self):

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -10,6 +10,7 @@ from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
 from caching.base import CachingManager, CachingMixin
 
+from opendebates import site_defaults
 
 NUMBER_OF_VOTES_CACHE_ENTRY = 'number_of_votes'
 RECENT_EVENTS_CACHE_ENTRY = 'recent_events_cache_entry'
@@ -45,20 +46,51 @@ class SiteMode(CachingMixin, models.Model):
     announcement_link = models.URLField(null=True, blank=True)
     announcement_page_regex = models.CharField(max_length=255, null=True, blank=True)
 
-    banner_header_title = models.TextField(default=u'Welcome to the<br>Open Debate')
-    banner_header_copy = models.TextField(default=u'Ask about the issues that are most '
-                                          'important to you -- then vote for other '
-                                          'important questions and encourage friends '
-                                          'to do the same!')
+    hashtag = models.CharField(default=site_defaults.HASHTAG, max_length=255)
 
-    popup_after_submission_text = models.TextField(default=u'Next, help your question '
-                                                   'collect votes. Share it on social '
-                                                   'media and email it to friends.')
+    banner_header_title = models.TextField(default=site_defaults.BANNER_HEADER_TITLE)
+    banner_header_copy = models.TextField(default=site_defaults.BANNER_HEADER_COPY)
+
+    popup_after_submission_text = models.TextField(
+        default=site_defaults.POPUP_AFTER_SUBMISSION_TEXT
+    )
+
+    email_subject = models.CharField(default=site_defaults.EMAIL_SUBJECT, max_length=998)
+    email_body = models.TextField(default=site_defaults.EMAIL_BODY)
+
+    facebook_image = models.URLField(default=site_defaults.FACEBOOK_IMAGE)
+    facebook_question_description = models.TextField(
+        default=site_defaults.FACEBOOK_QUESTION_DESCRIPTION
+    )
+    facebook_question_title = models.TextField(default=site_defaults.FACEBOOK_QUESTION_TITLE)
+    facebook_site_description = models.TextField(default=site_defaults.FACEBOOK_SITE_DESCRIPTION)
+    facebook_site_title = models.TextField(default=site_defaults.FACEBOOK_SITE_TITLE)
+
+    twitter_image = models.URLField(default=site_defaults.TWITTER_IMAGE)
+    twitter_question_description = models.TextField(
+        default=site_defaults.TWITTER_QUESTION_DESCRIPTION
+    )
+    twitter_question_text = models.TextField(default=site_defaults.TWITTER_QUESTION_TEXT)
+    twitter_question_title = models.TextField(default=site_defaults.TWITTER_QUESTION_TITLE)
+    twitter_site_description = models.TextField(default=site_defaults.TWITTER_SITE_DESCRIPTION)
+    twitter_site_text = models.TextField(default=site_defaults.TWITTER_SITE_TEXT)
+    twitter_site_title = models.TextField(default=site_defaults.TWITTER_SITE_TITLE)
 
     objects = CachingManager()
 
 
-class Submission(models.Model):
+class CachedSiteModeMixin(object):
+
+    @property
+    def site_mode(self):
+        # avoid lots of unneeded round trips to memcached in production
+        if not hasattr(self, '_cached_site_mode'):
+            from opendebates.utils import get_site_mode
+            self._cached_site_mode = get_site_mode()
+        return self._cached_site_mode
+
+
+class Submission(CachedSiteModeMixin, models.Model):
 
     def user_display_name(self):
         return self.voter.user_display_name()
@@ -125,13 +157,13 @@ class Submission(models.Model):
 
     def my_tweet_text(self):
         params = {
-            "hashtag": settings.SITE_THEME['HASHTAG'],
+            "hashtag": self.site_mode.hashtag,
         }
         return _(u"Vote for my progressive idea for @ThinkBigUS #%s(hashtag)s. "
                  "30 leaders in Congress will see top ideas!" % params)
 
     def tweet_text(self):
-        text = settings.SITE_THEME['TWITTER_QUESTION_TEXT']
+        text = self.site_mode.twitter_question_text
         if self.voter.twitter_handle:
             text += u" h/t @%s" % self.voter.twitter_handle
         return text
@@ -150,8 +182,8 @@ class Submission(models.Model):
         return u"//www.reddit.com/submit?url=%s" % (quote_plus(self.really_absolute_url('reddit')),)
 
     def email_url(self):
-        subject = settings.SITE_THEME['EMAIL_SUBJECT']
-        body = settings.SITE_THEME['EMAIL_BODY'] % {
+        subject = self.site_mode.email_subject
+        body = self.site_mode.email_body % {
             "url": self.really_absolute_url('email'),
         }
         return u"mailto:?subject=%s&body=%s" % (urlquote(subject), urlquote(body))
@@ -159,7 +191,7 @@ class Submission(models.Model):
     def sms_url(self):
         params = {
             "url": self.really_absolute_url('sms'),
-            "hashtag": settings.SITE_THEME['HASHTAG'],
+            "hashtag": self.site_mode.hashtag,
         }
         body = _(u"Vote for my progressive idea for @OpenDebaters #%(hashtag)s. %(url)s" % params)
         return u"sms:;?body=%s" % (quote_plus(body),)
@@ -180,18 +212,18 @@ class Submission(models.Model):
 
     def twitter_title(self):
         # Vote on this question for the FL-Sen #OpenDebate!
-        return settings.SITE_THEME['TWITTER_QUESTION_TITLE'].format(idea=self.idea)
+        return self.site_mode.twitter_question_title.format(idea=self.idea)
 
     def twitter_description(self):
         # "{idea}" At 8pm EDT on 4/25, Jolly & Grayson answer top vote-getting questions at
         # bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive Change Institute
-        return settings.SITE_THEME['TWITTER_QUESTION_DESCRIPTION'].format(idea=self.idea)
+        return self.site_mode.twitter_question_description.format(idea=self.idea)
 
     def facebook_title(self):
-        return settings.SITE_THEME['FACEBOOK_QUESTION_TITLE'].format(idea=self.idea)
+        return self.site_mode.facebook_question_title.format(idea=self.idea)
 
     def facebook_description(self):
-        return settings.SITE_THEME['FACEBOOK_QUESTION_DESCRIPTION'].format(idea=self.idea)
+        return self.site_mode.facebook_question_description.format(idea=self.idea)
 
 
 class ZipCode(CachingMixin, models.Model):

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -17,6 +17,7 @@ SUBMISSIONS_PER_PAGE = 25
 
 SITE_THEMES = ['testing', 'florida']
 SITE_THEME_NAME = 'florida'
+# SITE_THEME_NAME gets overriden in local_settings
 
 ENABLE_USER_DISPLAY_NAME = False
 

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -2,7 +2,6 @@
 from datetime import timedelta
 import os
 import sys
-from textwrap import dedent
 from django.utils.translation import ugettext_lazy as _
 import dj_database_url
 
@@ -16,117 +15,8 @@ SITE_DOMAIN_WITH_PROTOCOL = "https://" + SITE_DOMAIN
 
 SUBMISSIONS_PER_PAGE = 25
 
-SITE_THEMES = {
-    'florida': {
-        "HASHTAG": u"FLOpenDebate",
-        "TWITTER_IMAGE":
-            "https://s3.amazonaws.com/s3.boldprogressives.org/images/"
-            "OpenDebates_VOTE-NOW_TW-1024x512-FODUrl.png",
-        "TWITTER_SITE_TEXT":
-            u"VOTE & submit questions for #FLSen #OpenDebate between @DavidJollyFL & "
-            u"@AlanGrayson h/t @OpenDebates @ProgChangeInst",
-        "TWITTER_SITE_TITLE":
-            u"U.S. Senate candidates answer YOUR questions!",
-        "TWITTER_SITE_DESCRIPTION":
-            u"Voters set the agenda for groundbreaking #OpenDebate. Tune in Mon 4/25 @7pm EDT "
-            u"on TYTNetwork.com. Submit & vote here!",
-        "TWITTER_QUESTION_TEXT":
-            u"VOTE & submit questions for #FLSen #OpenDebate between @DavidJollyFL & @AlanGrayson "
-            u"h/t @OpenDebates @ProgChangeInst",
-        "TWITTER_QUESTION_TITLE":
-            u"Vote on this question for the FL-Sen #OpenDebate!",
-        "TWITTER_QUESTION_DESCRIPTION":
-            u'"{idea}" Debate is 4/25 at 7pm EDT on TYTNetwork.com.',
-
-        "FACEBOOK_IMAGE":
-            "https://s3.amazonaws.com/s3.boldprogressives.org/images/"
-            "OpenDebates_VOTE-NOW_FB-1200x717-FODUrl.png",
-        "FACEBOOK_SITE_TITLE":
-            u"HISTORIC: Florida U.S. Senate Candidates answer YOUR top-voted questions!",
-        "FACEBOOK_SITE_DESCRIPTION":
-            u"All questions for groundbreaking #OpenDebate on Mon 4/25 @7pm EDT on TYTNetwork.com "
-            u"will be chosen from top vote-getters online. Hosted by Open Debate Coalition",
-        "FACEBOOK_QUESTION_TITLE":
-            u'Click to vote on this question for Senate candidates to answer at the #OpenDebate '
-            u'in Florida!',
-        "FACEBOOK_QUESTION_DESCRIPTION":
-            u'"{idea}" Mon, 4/25 @7pm EDT on TYTNetwork.com, Jolly & Grayson answer YOUR '
-            u'questions!',
-
-        "EMAIL_SUBJECT":
-            "Help me set the agenda for the debate between Alan Grayson and David Jolly!",
-        "EMAIL_BODY":
-            dedent("""
-            Hi there!
-
-            I just participated in a first-of-its-kind Open Debate for U.S. Senate candidates in
-            Florida where all questions will be chosen from among the Top 30 voted on by the
-            public online.
-
-            Could you vote on this question so David Jolly and Alan Grayson can answer it live at
-            the debate?
-
-            %(url)s
-
-            There are tons of other great questions to vote on at FloridaOpenDebate.com. You can
-            search by topic area or keyword, or you can even submit your own question. Voting
-            closes just before the debate begins at 7:00 pm EDT on Monday, April 25. Tune in to
-            FloridaOpenDebate.com to watch this event, co-hosted by the Open Debate Coalition and
-            the Progressive Change Institute.
-
-            Thanks for helping us create a debate for U.S. Senate that reflects the real concerns
-            of Americans!"""),
-    },
-    'testing': {  # Presidential Debate
-        "HASHTAG": "DemOpenForum",
-
-        # FIXME: Twitter & Facebook settings for Presidential debate
-        "TWITTER_IMAGE":
-            "https://s3.amazonaws.com/s3.boldprogressives.org/images/"
-            "OpenDebates_VOTE-NOW_TW-1024x512-FODUrl.png",
-        "TWITTER_SITE_TEXT":
-            u"Submit & vote on questions for FL-Sen #OpenDebate between @DavidJollyFL "
-            "& @AlanGrayson hosted by Open Debate Coalition, Progressive Change Inst.",
-        "TWITTER_SITE_TITLE":
-            u"U.S. Senate candidates answer YOUR questions!",
-        "TWITTER_SITE_DESCRIPTION":
-            u"Mon 4/25 @8pm EDT on [TBD]: Voters set the agenda for groundbreaking #OpenDebate. "
-            "Submit & vote here!",
-        "TWITTER_QUESTION_TEXT":
-            u"Submit & vote on questions for FL-Sen #OpenDebate between @DavidJollyFL "
-            "& @AlanGrayson hosted by Open Debate Coalition, Progressive Change Inst.",
-        "TWITTER_QUESTION_TITLE":
-            u"Click here to vote on this question for U.S. Senate candidates to answer at "
-            "the #OpenDebate in Florida!",
-        "TWITTER_QUESTION_DESCRIPTION":
-            u'"{idea}" At 8pm EDT on 4/25, Jolly & Grayson answer top vote-getting questions '
-            'at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, '
-            'Progressive Change Institute',
-
-        "FACEBOOK_IMAGE":
-            "https://s3.amazonaws.com/s3.boldprogressives.org/images/"
-            "OpenDebates_VOTE-NOW_FB-1200x717-FODUrl.png",
-        "FACEBOOK_SITE_TITLE":
-            u"HISTORIC: Florida U.S. Senate Candidates answer YOUR top-voted questions!",
-        "FACEBOOK_SITE_DESCRIPTION":
-            u"Groundbreaking bottom-up #OpenDebate to take place Mon 4/25 @7pm EDT, hosted "
-            "by Open Debate Coalition, Progressive Change Institute, & [MEDIA PARTNER]. All "
-            "questions will be chosen from top vote-getters online. Submit & vote here!",
-        "FACEBOOK_QUESTION_TITLE":
-            u'Click here to vote on this question for U.S. Senate candidates to answer at the '
-            '#OpenDebate in Florida!',
-        "FACEBOOK_QUESTION_DESCRIPTION":
-            u'"{idea}" At 8pm EDT on 4/25, Jolly & Grayson answer top vote-getting questions '
-            'at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive '
-            'Change Institute',
-
-        "EMAIL_SUBJECT": "Vote for my progressive idea for @OpenDebaters",
-        "EMAIL_BODY": "Vote for my progressive idea for @OpenDebaters %(url)s",
-    },
-}
+SITE_THEMES = ['testing', 'florida']
 SITE_THEME_NAME = 'florida'
-SITE_THEME = SITE_THEMES[SITE_THEME_NAME]
-# SITE_THEME_NAME and SITE_THEME get overriden in local_settings
 
 ENABLE_USER_DISPLAY_NAME = False
 

--- a/opendebates/site_defaults.py
+++ b/opendebates/site_defaults.py
@@ -41,7 +41,7 @@ FACEBOOK_SITE_DESCRIPTION =\
     "questions will be chosen from top vote-getters online. Submit & vote here!"
 FACEBOOK_QUESTION_TITLE =\
     u'Click here to vote on this question for U.S. Senate candidates to answer at the '\
-    '#OpenDebate in [STATE!'
+    '#OpenDebate in [STATE]!'
 FACEBOOK_QUESTION_DESCRIPTION =\
     u'"{idea}" At [TIME] on [DATE], [CANDIDATES] answer top vote-getting questions '\
     'at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive '\

--- a/opendebates/site_defaults.py
+++ b/opendebates/site_defaults.py
@@ -19,7 +19,10 @@ TWITTER_SITE_TITLE = u"U.S. Senate candidates answer YOUR questions!"
 TWITTER_SITE_DESCRIPTION =\
     u"[DATE] [TIME] on [TBD]: Voters set the agenda for groundbreaking #OpenDebate. "\
     "Submit & vote here!"
-TWITTER_QUESTION_TEXT =\
+TWITTER_QUESTION_TEXT_WITH_HANDLE =\
+    u"Submit & vote on questions for #OpenDebate "\
+    "hosted by Open Debate Coalition, Progressive Change Inst. h/t @{handle}"
+TWITTER_QUESTION_TEXT_NO_HANDLE =\
     u"Submit & vote on questions for #OpenDebate "\
     "hosted by Open Debate Coalition, Progressive Change Inst."
 TWITTER_QUESTION_TITLE =\

--- a/opendebates/site_defaults.py
+++ b/opendebates/site_defaults.py
@@ -1,0 +1,51 @@
+HASHTAG = "DemOpenForum"
+
+BANNER_HEADER_TITLE = u'Welcome to the<br>Open Debate'
+BANNER_HEADER_COPY = \
+    u'Ask about the issues that are most important to you -- then vote for other '\
+    'important questions and encourage friends to do the same!'
+
+POPUP_AFTER_SUBMISSION_TEXT =\
+    u'Next, help your question collect votes. Share it on social media and email '\
+    'it to friends.'
+
+TWITTER_IMAGE =\
+    "https://s3.amazonaws.com/s3.boldprogressives.org/images/"\
+    "OpenDebates_VOTE-NOW_TW-1024x512-FODUrl.png"
+TWITTER_SITE_TEXT =\
+    u"Submit & vote on questions for the #OpenDebate "\
+    "hosted by Open Debate Coalition, Progressive Change Inst."
+TWITTER_SITE_TITLE = u"U.S. Senate candidates answer YOUR questions!"
+TWITTER_SITE_DESCRIPTION =\
+    u"[DATE] [TIME] on [TBD]: Voters set the agenda for groundbreaking #OpenDebate. "\
+    "Submit & vote here!"
+TWITTER_QUESTION_TEXT =\
+    u"Submit & vote on questions for #OpenDebate "\
+    "hosted by Open Debate Coalition, Progressive Change Inst."
+TWITTER_QUESTION_TITLE =\
+    u"Click here to vote on this question for U.S. Senate candidates to answer at "\
+    "the #OpenDebate in Florida!"
+TWITTER_QUESTION_DESCRIPTION =\
+    u'"{idea}" At [TIME] on [DAY, [CANDIDATES] answer top vote-getting questions '\
+    'at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, '\
+    'Progressive Change Institute'
+
+FACEBOOK_IMAGE =\
+    "https://s3.amazonaws.com/s3.boldprogressives.org/images/"\
+    "OpenDebates_VOTE-NOW_FB-1200x717-FODUrl.png"
+FACEBOOK_SITE_TITLE =\
+    u"HISTORIC: [CANDIDATES] answer YOUR top-voted questions!"
+FACEBOOK_SITE_DESCRIPTION =\
+    u"Groundbreaking bottom-up #OpenDebate to take place [DATE] @[TIME], hosted "\
+    "by Open Debate Coalition, Progressive Change Institute, & [MEDIA PARTNER]. All "\
+    "questions will be chosen from top vote-getters online. Submit & vote here!"
+FACEBOOK_QUESTION_TITLE =\
+    u'Click here to vote on this question for U.S. Senate candidates to answer at the '\
+    '#OpenDebate in [STATE!'
+FACEBOOK_QUESTION_DESCRIPTION =\
+    u'"{idea}" At [TIME] on [DATE], [CANDIDATES] answer top vote-getting questions '\
+    'at bottom-up #OpenDebate hosted by [TBD], Open Debate Coalition, Progressive '\
+    'Change Institute'
+
+EMAIL_SUBJECT = "Vote for my progressive idea for @OpenDebaters"
+EMAIL_BODY = "Vote for my progressive idea for @OpenDebaters %(url)s"

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -10,19 +10,19 @@
     <meta name="twitter:card" content="summary_large_image">
     {# <meta name="twitter:site" content="@Opendebaters"> #}
     {# <meta name="twitter:creator" content="@Opendebaters"> #}
-    <meta name="twitter:title" content="{{ SITE_THEME.TWITTER_SITE_TITLE }}">
-    <meta name="twitter:description" content="{{ SITE_THEME.TWITTER_SITE_DESCRIPTION }}">
-    <meta name="twitter:image" content="{{ SITE_THEME.TWITTER_IMAGE }}">
+    <meta name="twitter:title" content="{{ SITE_MODE.twitter_site_title }}">
+    <meta name="twitter:description" content="{{ SITE_MODE.twitter_site_description }}">
+    <meta name="twitter:image" content="{{ SITE_MODE.twitter_image }}">
 
     <meta property="og:url" content="{{ SITE_LINK }}"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:title" content="{{ SITE_THEME.FACEBOOK_SITE_TITLE }}"/>
-    <meta property="og:description" content="{{ SITE_THEME.FACEBOOK_SITE_DESCRIPTION }}"/>
-    <meta property="og:image" content="{{ SITE_THEME.FACEBOOK_IMAGE }}"/>
+    <meta property="og:title" content="{{ SITE_MODE.facebook_site_title }}"/>
+    <meta property="og:description" content="{{ SITE_MODE.facebook_site_description }}"/>
+    <meta property="og:image" content="{{ SITE_MODE.facebook_image }}"/>
   {% endblock metadata %}
   {% load pipeline %}
   {% stylesheet 'base' %}
-  {% if SITE_THEME %}
+  {% if SITE_THEME_NAME %}
     {% with "theme-"|add:SITE_THEME_NAME as theme %}
       {% stylesheet theme %}
     {% endwith %}

--- a/opendebates/templates/opendebates/snippets/idea.html
+++ b/opendebates/templates/opendebates/snippets/idea.html
@@ -1,8 +1,10 @@
 {% load i18n %}
 {% load l10n %}
 {% load cache %}
+{% load opendebates_tags %}
 
 {% cache 30 question idea.id show_duplicates %}
+{% provide_site_mode_to idea %}
 <div id="i{{ idea.id }}" data-idea-id="{{ idea.id }}" class="big-idea clearfix">
     <div class="votes col-md-3">
       {% if is_duplicate %}

--- a/opendebates/templates/opendebates/vote.html
+++ b/opendebates/templates/opendebates/vote.html
@@ -7,13 +7,13 @@
   {# <meta name="twitter:creator" content="@Opendebaters"> #}
   <meta name="twitter:title" content="{{ idea.twitter_title }}">
   <meta name="twitter:description" content="{{ idea.twitter_description }}">
-  <meta name="twitter:image" content="{{ SITE_THEME.TWITTER_IMAGE }}">
+  <meta name="twitter:image" content="{{ SITE_MODE.twitter_image }}">
 
   <meta property="og:url" content="{{ idea.really_absolute_url }}"/>
   <meta property="og:type" content="website"/>
   <meta property="og:title" content="{{ idea.facebook_title }}"/>
   <meta property="og:description" content="{{ idea.facebook_description }}"/>
-  <meta property="og:image" content="{{ SITE_THEME.FACEBOOK_IMAGE }}"/>
+  <meta property="og:image" content="{{ SITE_MODE.facebook_image }}"/>
 {% endblock metadata %}
 
 {% block title %}

--- a/opendebates/templatetags/opendebates_tags.py
+++ b/opendebates/templatetags/opendebates_tags.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def provide_site_mode_to(context, obj):
+    """
+    Convenience method to add the SiteMode object available in the template
+    context to a model object (such as Submission). Helps avoid a call out to
+    the cache for each Submission in opendebates/list_ideas.html.
+    """
+    obj._cached_site_mode = context['SITE_MODE']
+    return ''

--- a/opendebates/tests/test_context_processors.py
+++ b/opendebates/tests/test_context_processors.py
@@ -1,10 +1,11 @@
 import urlparse
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from mock import patch, Mock
 
 from opendebates.context_processors import global_vars
 from opendebates.tests.factories import SubmissionFactory
+from opendebates.utils import get_site_mode
 
 
 class NumberOfVotesTest(TestCase):
@@ -21,11 +22,11 @@ class ThemeTests(TestCase):
     def setUp(self):
         self.idea = SubmissionFactory()
 
-    @override_settings(SITE_THEME={
-        'EMAIL_SUBJECT': 'THE EMAIL SUBJECT',
-        'EMAIL_BODY': 'THE EMAIL BODY\nAND SECOND LINE',
-    })
     def test_email_url(self):
+        mode = get_site_mode()
+        mode.email_subject = 'THE EMAIL SUBJECT'
+        mode.email_body = 'THE EMAIL BODY\nAND SECOND LINE'
+        mode.save()
         email_url = self.idea.email_url()
         fields = urlparse.parse_qs(urlparse.urlparse(email_url).query)
         self.assertTrue('subject' in fields, fields)

--- a/opendebates/tests/test_sharing.py
+++ b/opendebates/tests/test_sharing.py
@@ -3,9 +3,13 @@ from django.test import TestCase
 from django.utils.html import escape
 
 from opendebates.tests.factories import SubmissionFactory
+from opendebates.utils import get_site_mode
 
 
 class FacebookTest(TestCase):
+    def setUp(self):
+        self.mode = get_site_mode()
+
     def test_facebook_site(self):
         rsp = self.client.get('/')
         self.assertContains(
@@ -19,16 +23,16 @@ class FacebookTest(TestCase):
         self.assertContains(
             rsp,
             '<meta property="og:title" content="%s"/>'
-            % escape(settings.SITE_THEME['FACEBOOK_SITE_TITLE'])
+            % escape(self.mode.facebook_site_title)
         )
         self.assertContains(
             rsp,
             '<meta property="og:description" content="%s"/>'
-            % escape(settings.SITE_THEME['FACEBOOK_SITE_DESCRIPTION'])
+            % escape(self.mode.facebook_site_description)
         )
         self.assertContains(
             rsp,
-            '<meta property="og:image" content="%s"/>' % settings.SITE_THEME['FACEBOOK_IMAGE']
+            '<meta property="og:image" content="%s"/>' % self.mode.facebook_image
         )
 
     def test_facebook_question(self):
@@ -45,47 +49,50 @@ class FacebookTest(TestCase):
         self.assertContains(
             rsp,
             '<meta property="og:title" content="%s"/>'
-            % escape(settings.SITE_THEME['FACEBOOK_QUESTION_TITLE'])
+            % escape(self.mode.facebook_question_title)
         )
         self.assertContains(
             rsp,
             '<meta property="og:description" content="%s"/>'
-            % escape(settings.SITE_THEME['FACEBOOK_QUESTION_DESCRIPTION']
+            % escape(self.mode.facebook_question_description
                      .format(idea=question.idea))
         )
         self.assertContains(
             rsp,
-            '<meta property="og:image" content="%s"/>' % settings.SITE_THEME['FACEBOOK_IMAGE']
+            '<meta property="og:image" content="%s"/>' % self.mode.facebook_image
         )
 
     def test_facebook_title(self):
         question = SubmissionFactory(idea="Bogus & Broken")
         self.assertEqual(
-            settings.SITE_THEME['FACEBOOK_QUESTION_TITLE'].format(idea=question.idea),
+            self.mode.facebook_question_title.format(idea=question.idea),
             question.facebook_title()
         )
 
     def test_facebook_description(self):
         question = SubmissionFactory(idea="Bogus & Broken")
         self.assertEqual(
-            settings.SITE_THEME['FACEBOOK_QUESTION_DESCRIPTION'].format(idea=question.idea),
+            self.mode.facebook_question_description.format(idea=question.idea),
             question.facebook_description()
         )
 
 
 class TwitterTest(TestCase):
+    def setUp(self):
+        self.mode = get_site_mode()
+
     def test_twitter_site_card(self):
         rsp = self.client.get('/')
         self.assertContains(rsp, '<meta name="twitter:card" content="summary_large_image">')
         self.assertContains(rsp,
                             '<meta name="twitter:title" content="%s">'
-                            % escape(settings.SITE_THEME['TWITTER_SITE_TITLE']))
+                            % escape(self.mode.twitter_site_title))
         self.assertContains(rsp,
                             '<meta name="twitter:description" content="%s">'
-                            % escape(settings.SITE_THEME['TWITTER_SITE_DESCRIPTION']))
+                            % escape(self.mode.twitter_site_description))
         self.assertContains(
             rsp,
-            '<meta name="twitter:image" content="%s">' % settings.SITE_THEME['TWITTER_IMAGE']
+            '<meta name="twitter:image" content="%s">' % self.mode.twitter_image
         )
 
     def test_twitter_question_card(self):
@@ -100,19 +107,19 @@ class TwitterTest(TestCase):
                             % escape(question.twitter_description()))
         self.assertContains(
             rsp,
-            '<meta name="twitter:image" content="%s">' % settings.SITE_THEME['TWITTER_IMAGE']
+            '<meta name="twitter:image" content="%s">' % self.mode.twitter_image
         )
 
     def test_twitter_title(self):
         question = SubmissionFactory(idea="Bogus & Broken")
         self.assertEqual(
-            settings.SITE_THEME['TWITTER_QUESTION_TITLE'].format(idea=question.idea),
+            self.mode.twitter_question_title.format(idea=question.idea),
             question.twitter_title()
         )
 
     def test_twitter_description(self):
         question = SubmissionFactory(idea="Bogus & Broken")
         self.assertEqual(
-            settings.SITE_THEME['TWITTER_QUESTION_DESCRIPTION'].format(idea=question.idea),
+            self.mode.twitter_question_description.format(idea=question.idea),
             question.twitter_description()
         )

--- a/opendebates/tests/test_views.py
+++ b/opendebates/tests/test_views.py
@@ -3,8 +3,6 @@ import mock
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from opendebates.models import SiteMode
-
 from .factories import SubmissionFactory
 
 
@@ -16,8 +14,12 @@ class ListIdeasTest(TestCase):
         for i in range(10):
             SubmissionFactory()
 
-    @mock.patch('opendebates.utils.get_site_mode')
-    def test_list_ideas_calls_get_site_mode_only_once(self, gsm_mock):
-        gsm_mock.return_value = SiteMode.objects.get_or_create()[0]
+    @mock.patch('opendebates.models.Submission._get_site_mode')
+    def test_list_ideas_uses_site_mode_from_context(self, gsm_mock):
+        """
+        The _get_site_mode method in the Submission model shouldn't be called
+        at all during list_ideas if we've successfully provided the SITE_MODE
+        in the template context to the model.
+        """
         self.client.get(self.url)
-        self.assertEqual(gsm_mock.call_count, 1)
+        self.assertEqual(gsm_mock.call_count, 0)

--- a/opendebates/tests/test_views.py
+++ b/opendebates/tests/test_views.py
@@ -1,0 +1,23 @@
+import mock
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from opendebates.models import SiteMode
+
+from .factories import SubmissionFactory
+
+
+class ListIdeasTest(TestCase):
+
+    def setUp(self):
+        self.url = reverse('list_ideas')
+
+        for i in range(10):
+            SubmissionFactory()
+
+    @mock.patch('opendebates.utils.get_site_mode')
+    def test_list_ideas_calls_get_site_mode_only_once(self, gsm_mock):
+        gsm_mock.return_value = SiteMode.objects.get_or_create()[0]
+        self.client.get(self.url)
+        self.assertEqual(gsm_mock.call_count, 1)


### PR DESCRIPTION
Lilia would like the ability to edit various strings on the site without re-deploying and without engaging a developer. This PR moves the remaining settings from `SITE_THEMES` into the `SiteMode` model.
