### PR TITLE
Add SiteMode.inline_css option for admins to override styles on the fly

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -53,8 +53,10 @@ class SiteModeAdmin(ModelAdmin):
     _fields = [f.name for f in models.SiteMode._meta.get_fields() if f.name != 'id']
     fieldsets = [
         ('General Settings', {
-            'fields': ['show_question_votes', 'show_total_votes', 'allow_sorting_by_votes',
-                       'allow_voting_and_submitting_questions']
+            'fields': ['show_question_votes', 'show_total_votes',
+                       'allow_sorting_by_votes',
+                       'allow_voting_and_submitting_questions',
+                       'inline_css']
         }),
         ('Debate Details', {
             'fields': [f for f in _fields if f.startswith('debate_')],

--- a/opendebates/migrations/0027_sitemode_inline_css.py
+++ b/opendebates/migrations/0027_sitemode_inline_css.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0026_voter_phone_number'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='inline_css',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/opendebates/migrations/0027_sitemode_inline_css.py
+++ b/opendebates/migrations/0027_sitemode_inline_css.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='sitemode',
             name='inline_css',
-            field=models.TextField(null=True, blank=True),
+            field=models.TextField(blank=True),
         ),
     ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -42,7 +42,7 @@ class SiteMode(CachingMixin, models.Model):
     )
     debate_state = models.CharField(max_length=5, null=True, blank=True)
 
-    inline_css = models.TextField(null=True, blank=True)
+    inline_css = models.TextField(blank=True)
 
     announcement_headline = models.CharField(max_length=255, null=True, blank=True)
     announcement_body = models.TextField(null=True, blank=True)

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -42,6 +42,8 @@ class SiteMode(CachingMixin, models.Model):
     )
     debate_state = models.CharField(max_length=5, null=True, blank=True)
 
+    inline_css = models.TextField(null=True, blank=True)
+
     announcement_headline = models.CharField(max_length=255, null=True, blank=True)
     announcement_body = models.TextField(null=True, blank=True)
     announcement_link = models.URLField(null=True, blank=True)

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -33,7 +33,11 @@
   <link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,300,600,400|Open+Sans+Condensed:700"
         rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-
+  {% if SITE_MODE.inline_css %}
+  <style type="text/css">
+    {{ SITE_MODE.inline_css|safe }}
+  </style>
+  {% endif %}
 </head>
 <body>
 

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -57,8 +57,10 @@
     <div class="header-logos">
       <a href="{% url 'list_ideas' %}">
         <img src="{% static "images/badge-democratic-open-forum.png" %}">
-        <img src="{% static "images/logo-header-partner-1.png" %}">
-        <img src="{% static "images/logo-header-partner-2.png" %}">
+        <img class="partner-logo partner-logo-1"
+             src="{% static "images/logo-header-partner-1.png" %}">
+        <img class="partner-logo partner-logo-1"
+             src="{% static "images/logo-header-partner-2.png" %}">
       </a>
     </div>
     <div class="login-container{% if request.user.is_authenticated %} login-container-authenticated{% endif %}">
@@ -77,8 +79,10 @@
       <h1><a href="/">{{ BANNER_HEADER_TITLE|safe }}</a></h1>
       <div class="header-copy">{{ BANNER_HEADER_COPY|safe }}</div>
       <div class="header-small-logos">
-        <img src="{% static "images/logo-header-partner-1.png" %}">
-        <img src="{% static "images/logo-header-partner-2.png" %}">
+        <img class="partner-logo partner-logo-1"
+             src="{% static "images/logo-header-partner-1.png" %}">
+        <img class="partner-logo partner-logo-2"
+             src="{% static "images/logo-header-partner-2.png" %}">
       </div>
       <div class="header-bottom">
         <div class="header-votes">

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -59,7 +59,7 @@
         <img src="{% static "images/badge-democratic-open-forum.png" %}">
         <img class="partner-logo partner-logo-1"
              src="{% static "images/logo-header-partner-1.png" %}">
-        <img class="partner-logo partner-logo-1"
+        <img class="partner-logo partner-logo-2"
              src="{% static "images/logo-header-partner-2.png" %}">
       </a>
     </div>

--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -34,7 +34,7 @@
         rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   {% if SITE_MODE.inline_css %}
-  <style type="text/css">
+  <style type="text/css" id="site-mode-inline-css">
     {{ SITE_MODE.inline_css|safe }}
   </style>
   {% endif %}

--- a/opendebates/tests/test_site_mode.py
+++ b/opendebates/tests/test_site_mode.py
@@ -7,7 +7,6 @@ class AnnouncementTest(TestCase):
 
     def setUp(self):
         self.mode, _ = SiteMode.objects.get_or_create()
-        self.mode.save()
         self.url = '/'
 
     def test_default_no_announcement(self):
@@ -92,7 +91,6 @@ class InlineCSSTest(TestCase):
 
     def setUp(self):
         self.mode, _ = SiteMode.objects.get_or_create()
-        self.mode.save()
         self.url = '/'
 
     def test_default_no_inline_css(self):

--- a/opendebates/tests/test_site_mode.py
+++ b/opendebates/tests/test_site_mode.py
@@ -86,3 +86,43 @@ class AnnouncementTest(TestCase):
         rsp = self.client.get('/')
         self.assertIn('<div class="site-announcement warning">', rsp.content)
         self.assertIn('<a href="%s">' % link, rsp.content)
+
+
+class InlineCSSTest(TestCase):
+
+    def setUp(self):
+        self.mode, _ = SiteMode.objects.get_or_create()
+        self.mode.save()
+        self.url = '/'
+
+    def test_default_no_inline_css(self):
+        rsp = self.client.get(self.url)
+        self.assertNotIn(u'<style type="text/css" id="site-mode-inline-css">',
+                         rsp.content)
+
+    def test_inline_css(self):
+        css = u"header { background: green !important; }"
+        self.mode.inline_css = css
+        self.mode.save()
+
+        rsp = self.client.get(self.url)
+        self.assertIn(u'<style type="text/css" id="site-mode-inline-css">',
+                      rsp.content)
+        self.assertIn(css, rsp.content)
+
+        rsp = self.client.get('/registration/login/')
+        self.assertIn(css, rsp.content)
+
+    def test_admins_can_be_pretty_malicious_with_inline_css(self):
+        """
+        @@TODO maybe content should be validated as legitimate CSS;
+        at the moment there's no validation or html-escaping anywhere.
+        """
+        css = u"</style></head><body></body></html>"
+        self.mode.inline_css = css
+        self.mode.save()
+
+        rsp = self.client.get(self.url)
+        self.assertIn(u'<style type="text/css" id="site-mode-inline-css">',
+                      rsp.content)
+        self.assertIn(css, rsp.content)


### PR DESCRIPTION
I wrote this to depend on #191 (in migration order) but can redo it if there ends up being a reason not to merge #191 first.

Do you think this merits a test?

Also debated adding validation (e.g. with tinycss) so that admins have confidence they won't break things with a typo'ed css line (or, worse, a stray `</style></head><body></body></html>` in their css content...) but felt it's probably not worth doing now.
