### PR TITLE
Presidential instance sizes

### DIFF
--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -175,7 +175,7 @@
       web: c3.xlarge # for faster AMI creation (no swap file)
       worker: m4.large
     presidential:
-      cache: m4.2xlarge # for 1000Mbps network
+      cache: c4.2xlarge # for 1000Mbps network
       db-master: m4.2xlarge
       db-slave: m4.2xlarge
       web: c3.xlarge # for faster AMI creation (no swap file)
@@ -208,11 +208,11 @@
 # hold your data plus a swap file (these instance types have no local storage).
   volume_sizes:
     testing:
-      cache: 10
-      db-master: 250
-      db-slave: 250
-      web: 10
-      worker: 50
+      cache: 25 # 10 GB data + 15 GB swap
+      db-master: 132 # 100 GB data + 32 GB swap
+      db-slave: 132 # 100 GB data + 32 GB swap
+      web: 10 # 10 GB data (no swap)
+      worker: 66 # 50 GB data + 16 GB swap
     staging:
       cache: 10
       db-master: 100
@@ -220,17 +220,17 @@
       web: 10
       worker: 50
     florida:
-      cache: 10
-      db-master: 250
-      db-slave: 250
-      web: 10
-      worker: 50
+      cache: 25 # 10 GB data + 15 GB swap
+      db-master: 282 # 250 GB data + 32 GB swap
+      db-slave: 282 # 250 GB data + 32 GB swap
+      web: 10 # 10 GB data (no swap)
+      worker: 66 # 50 GB data + 16 GB swap
     presidential:
-      cache: 10
-      db-master: 250
-      db-slave: 250
-      web: 10
-      worker: 50
+      cache: 25 # 10 GB data + 15 GB swap
+      db-master: 282 # 250 GB data + 32 GB swap
+      db-slave: 282 # 250 GB data + 32 GB swap
+      web: 10 # 10 GB data (no swap)
+      worker: 66 # 50 GB data + 16 GB swap
 
 # Mapping of Fabric environment and role to Elastic Block Device volume types
 # Use SSD-backed storage (gp2) for all servers. Change to 'standard' for slower

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -144,13 +144,22 @@
     web: [opendebates-sg, opendebates-web-sg]
 
 # Mapping of environment and role to EC2 instance types (sizes)
+# Except for very small instance types where it doesn't matter as much,
+# it's best to use 'c3' or 'm3' generation instances that have local SSD
+# storage for swap. This is especially true for 'web' instances that will
+# be used to create AMIs (and keep a small volume_size), as it dramatically
+# speeds up AMI creation (by ~10 min).
+# Additionally, 2xlarge or higher instance types are needed to get >= 1000 Mbps
+# on the network. This is important for the cache server which might not have
+# a lot of CPU load but will be transfering lots of data back & forth. See:
+# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-ec2-config.html
   instance_types:
     testing:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
+      cache: c3.2xlarge # for 1000Mbps network
+      db-master: c3.2xlarge
+      db-slave: c3.2xlarge
+      web: c3.xlarge
+      worker: m3.large
     staging:
       cache: t2.micro
       db-master: t2.small
@@ -158,17 +167,17 @@
       web: t2.micro
       worker: t2.micro
     florida:
-      cache: c4.large
-      db-master: m4.2xlarge
-      db-slave: m4.2xlarge
-      web: c4.xlarge
-      worker: m4.large
+      cache: c3.large
+      db-master: c3.2xlarge
+      db-slave: c3.2xlarge
+      web: c3.xlarge
+      worker: m3.large
     presidential:
-      cache: t2.micro
-      db-master: t2.small
-      db-slave: t2.small
-      web: t2.micro
-      worker: t2.micro
+      cache: c3.2xlarge # for 1000Mbps network
+      db-master: c3.2xlarge
+      db-slave: c3.2xlarge
+      web: c3.xlarge
+      worker: m3.large
 
 # Mapping of Fabric environment names to AWS load balancer names.  Load
 # balancers can be configured in the AWS Management Console.
@@ -192,13 +201,15 @@
       florida: opendebates-florida-ag
       presidential: opendebates-presidential-ag
 
-# Mapping of Fabric environment and role to Elastic Block Device sizes (in GB)
+# Mapping of Fabric environment and role to Elastic Block Device sizes (in GB).
+# If you have any 'm4' or 'c4' instances, make sure these are large enough to
+# hold your data plus a swap file (these instance types have no local storage).
   volume_sizes:
     testing:
       cache: 10
       db-master: 250
       db-slave: 250
-      web: 30
+      web: 10
       worker: 50
     staging:
       cache: 10
@@ -210,13 +221,13 @@
       cache: 10
       db-master: 250
       db-slave: 250
-      web: 30
+      web: 10
       worker: 50
     presidential:
       cache: 10
       db-master: 250
       db-slave: 250
-      web: 30
+      web: 10
       worker: 50
 
 # Mapping of Fabric environment and role to Elastic Block Device volume types

--- a/fabulaws-config.yml
+++ b/fabulaws-config.yml
@@ -145,21 +145,23 @@
 
 # Mapping of environment and role to EC2 instance types (sizes)
 # Except for very small instance types where it doesn't matter as much,
-# it's best to use 'c3' or 'm3' generation instances that have local SSD
-# storage for swap. This is especially true for 'web' instances that will
-# be used to create AMIs (and keep a small volume_size), as it dramatically
-# speeds up AMI creation (by ~10 min).
+# it's best to use 'c3' or 'm3' generation instances with local SSD storage
+# for 'web' instances that will be used to create AMIs (and use a small
+# volume_size), as it dramatically speeds up AMI creation (by ~10 min).
+# The c4 and m4 suite of instances support EBS optimization by default and
+# may be better for database or other high-I/O services:
+# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html#ebs-optimization-support
 # Additionally, 2xlarge or higher instance types are needed to get >= 1000 Mbps
 # on the network. This is important for the cache server which might not have
 # a lot of CPU load but will be transfering lots of data back & forth. See:
 # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-ec2-config.html
   instance_types:
     testing:
-      cache: c3.2xlarge # for 1000Mbps network
-      db-master: c3.2xlarge
-      db-slave: c3.2xlarge
-      web: c3.xlarge
-      worker: m3.large
+      cache: c4.2xlarge # for 1000Mbps network
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c3.xlarge # for faster AMI creation (no swap file)
+      worker: m4.large
     staging:
       cache: t2.micro
       db-master: t2.small
@@ -167,17 +169,17 @@
       web: t2.micro
       worker: t2.micro
     florida:
-      cache: c3.large
-      db-master: c3.2xlarge
-      db-slave: c3.2xlarge
-      web: c3.xlarge
-      worker: m3.large
+      cache: c4.large
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c3.xlarge # for faster AMI creation (no swap file)
+      worker: m4.large
     presidential:
-      cache: c3.2xlarge # for 1000Mbps network
-      db-master: c3.2xlarge
-      db-slave: c3.2xlarge
-      web: c3.xlarge
-      worker: m3.large
+      cache: m4.2xlarge # for 1000Mbps network
+      db-master: m4.2xlarge
+      db-slave: m4.2xlarge
+      web: c3.xlarge # for faster AMI creation (no swap file)
+      worker: m4.large
 
 # Mapping of Fabric environment names to AWS load balancer names.  Load
 # balancers can be configured in the AWS Management Console.


### PR DESCRIPTION
Proposed instance sizes for Fall 2016 presidential debate:
- Loosely based on instance sizes used in the Spring
- For the web servers, `c3` generation instances are used instead of `c4` so that we get local SSDs for swap. This has the added benefits of (a) speeding up instance/AMI creation time and (b) eliminating the need to adjust EBS volume sizes to account for large swapfiles on particularly large instance types.
- Uses `c4.2xlarge` for the cache server, as this is the cheapest instance that supports at least 1000Mbps
- Reduced web server volume sizes to 10GB as the space isn't used anyways when no swap file is required (base install uses something like 250MB, and the only thing likely to use more is logging)
