### PR TITLE
Allow admins to create "Watch Now" page & redirect visitors to it

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -46,6 +46,18 @@ class FlagAdmin(ModelAdmin):
     raw_id_fields = ['to_remove', 'duplicate_of', 'voter']
 
 
+@register(models.FlatPageMetadataOverride)
+class FlatPageMetadataOverrideAdmin(ModelAdmin):
+    list_display = ['flatpage_url']
+
+    def flatpage_url(self, obj):
+        return obj.page.url
+
+    def get_queryset(self, request):
+        return super(FlatPageMetadataOverrideAdmin, self).get_queryset(
+            request).select_related("page")
+
+
 @register(models.SiteMode)
 class SiteModeAdmin(ModelAdmin):
     list_display = ['debate_time', 'show_question_votes', 'show_total_votes',

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -343,3 +343,9 @@ class Flag(models.Model):
         unique_together = [
             ('to_remove', 'voter'),
         ]
+
+
+class FlatPageMetadataOverride(models.Model):
+    page = models.OneToOneField('flatpages.FlatPage',
+                                related_name='metadata')
+    metadata_html = models.TextField()

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -42,6 +42,8 @@ class SiteMode(CachingMixin, models.Model):
     )
     debate_state = models.CharField(max_length=5, null=True, blank=True)
 
+    redirect_site_to_url = models.CharField(max_length=100, blank=True)
+
     inline_css = models.TextField(blank=True)
 
     announcement_headline = models.CharField(max_length=255, null=True, blank=True)

--- a/opendebates/templates/flatpages/default.html
+++ b/opendebates/templates/flatpages/default.html
@@ -1,4 +1,16 @@
 {% extends "opendebates/base.html" %}
+{% load opendebates_tags %}
+
+{% block metadata %}
+{% with flatpage|flatpage_metadata as metadata %}
+{% if metadata %}
+{{ metadata.metadata_html|safe }}
+{% else %}
+{{ block.super }}
+{% endif %}
+{% endwith %}
+{% endblock %}
+
 {% block content %}
 
 <div class="row flatpage">

--- a/opendebates/templatetags/opendebates_tags.py
+++ b/opendebates/templatetags/opendebates_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from opendebates.models import FlatPageMetadataOverride
 
 register = template.Library()
 
@@ -12,3 +13,11 @@ def provide_site_mode_to(context, obj):
     """
     obj._cached_site_mode = context['SITE_MODE']
     return ''
+
+
+@register.filter
+def flatpage_metadata(flatpage):
+    try:
+        return flatpage.metadata
+    except FlatPageMetadataOverride.DoesNotExist:
+        return None

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -157,3 +157,13 @@ def allow_voting_and_submitting_questions():
 
 def get_local_votes_state():
     return get_site_mode().debate_state
+
+
+def should_redirect_to_url(request):
+    if 'page' in request.GET or 'sort' in request.GET:
+        return False
+    if 'HTTP_REFERER' in request.META \
+       and request.META['HTTP_REFERER'].startswith(settings.SITE_DOMAIN):
+        return False
+    url = get_site_mode().redirect_site_to_url
+    return url or False

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -21,7 +21,8 @@ from .models import Submission, Voter, Vote, Category, Candidate, ZipCode, \
 from .router import readonly_db
 from .utils import get_ip_address_from_request, get_headers_from_request, choose_sort, sort_list, \
     vote_needs_captcha, registration_needs_captcha, show_question_votes, \
-    allow_voting_and_submitting_questions, get_local_votes_state
+    allow_voting_and_submitting_questions, get_local_votes_state, \
+    should_redirect_to_url
 # from opendebates_comments.forms import CommentForm
 from opendebates_emails.models import send_email
 
@@ -80,6 +81,11 @@ def recent_activity(request):
 
 @rendered_with("opendebates/list_ideas.html")
 def list_ideas(request):
+
+    redirect_url = should_redirect_to_url(request)
+    if redirect_url:
+        return redirect(redirect_url)
+
     ideas = Submission.objects.all()
     citations_only = request.GET.get("citations_only")
     sort = choose_sort(request.GET.get('sort'))
@@ -158,6 +164,11 @@ def category_search(request, cat_id):
 @allow_http("GET", "POST")
 def vote(request, id):
     """Despite the name, this is both the page for voting AND the detail page for submissions"""
+
+    redirect_url = should_redirect_to_url(request)
+    if redirect_url:
+        return redirect(redirect_url)
+
     try:
         with readonly_db():
             idea = Submission.objects.get(id=id, approved=True)


### PR DESCRIPTION
Opening this more for discussion than for careful review, because I don't love my approach here.  (So I haven't written any migrations or tests yet.)  Sorry for the very long writeup here and for all my open questions / indecision...

Recap/summary: for the Florida debate, about thirty minutes before the live debate started, we:
- created a flatpage (https://floridaopendebate.com/watch/) with an embedded youtube stream, twitter feed, and some share buttons
- realized that we needed to let people share this page with custom fb/twitter metadata (e.g. a new og:image graphic that says "WATCH NOW" instead of "VOTE NOW"), so we created a flatpage template to override the sitewide social metadata tags (PR #171 and #172 from the spring)
- set up some cloudflare page rules to redirect all traffic landing on the home page -> the watch page instead
- realized that we needed to let people still browse through the original questions somehow, so we set up some more cloudflare rules to disable the redirects on sorted or paginated homepage views -- so we could then link safely to https://floridaopendebate.com/?sort=-votes

This PR allows us to recreate those behaviors without touching cloudflare and without any hardcoded content:
- Add a `SiteMode.redirect_site_to_url` field.  If set to a string, then the homepage and individual question view will immediately begin redirecting all traffic to that url.
- However, if the query string contains ?sort or ?page, traffic will remain non-redirected.  This lets us link to sorted views of the list_ideas screen.
- Also, if the referer is another page on the site, traffic will remain non-redirected.  This lets visitors click through from list_ideas to an individual question screen to see that question, while ensuring that social traffic that lands directly on an individual question WILL get kicked over to the watch page.
- The /category/ and /search/ views aren't affected by this redirect behavior at all, so visitors can always continue to use those.
- Add a `FlatPageMetadataOverride` model and template filter, and adjust the `flatpages/default.html` template to use it.  This allows site admins to set up custom social meta tags on a page-by-page basis, so that they can create unique meta tags for the "WATCH NOW" page when it is created.  (Which could probably also be accomplished by temporarily changing the content of the existing SiteMode social fields, but this ensures that we don't have to worry about facebook's open graph cache, which I always find hard to clear reliably.)

Notes:
- The actual content of the "WATCH NOW" page would still be built as raw html in a flatpage -- that way we don't have to worry ahead of time about whether the video feed will be coming from youtube vs facebook, what sort of social share buttons need to be created, whether the team needs a link to the top 30 questions on the page, etc.
- Not convinced that I needed to do that FlatPageMetadataOverride thing, but I feel like it might be safer, and the flexibility to do it per page might be needed?  But also wondering if I should just attach this to a path instead of a flatpage FK.  (In that case it might make sense to do individual fields instead of a giant html block, and also to refactor the SiteMode social settings into a shared model.)  
- I _didn't_ create a datetime field for when the redirect should kick in, contrary to what we discussed on the call.  I realized that there's a lot of other SiteMode features which need to be set at the last minute already -- e.g. turning off voting and submitting questions, setting up an announcement headline/body/link.  I also realized that the existing "Debate time" field is probably already the one we would want to use?  So I thought it might be better to discuss this further before changing anything.
- I wonder if the redirect logic should be made much more straightforward and consistent (e.g. do it in a middleware that redirects all pages unless there's a "?no_redirect" url parameter .. or just have a redirect_traffic_if_request_path_matches_regex field)
