### PR TITLE
[WIP] Separately track the vote counts since the previous debate

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -88,6 +88,7 @@ class TopSubmissionCategoryAdmin(ModelAdmin):
 class SiteModeAdmin(ModelAdmin):
     list_display = ['debate_time', 'previous_debate_time', 'show_question_votes',
                     'show_total_votes', 'allow_sorting_by_votes']
+    actions = ['reset_current_votes']
     _fields = [f.name for f in models.SiteMode._meta.get_fields() if f.name != 'id']
     fieldsets = [
         ('General Settings', {
@@ -136,6 +137,11 @@ class SiteModeAdmin(ModelAdmin):
     _missed_fields = set(_fields) - _used_fields
     if _missed_fields:
         fieldsets.append(('Other', {'fields': sorted(list(_missed_fields))}))
+
+    def reset_current_votes(self, request, queryset):
+        # Note, currently all submissions are under the one and only SiteMode.
+        models.Submission.objects.update(current_votes=0)
+    reset_current_votes.short_description = "Reset vote counts since the last debate"
 
 
 @register(models.FlatPageMetadataOverride)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -86,8 +86,8 @@ class TopSubmissionCategoryAdmin(ModelAdmin):
 
 @register(models.SiteMode)
 class SiteModeAdmin(ModelAdmin):
-    list_display = ['debate_time', 'show_question_votes', 'show_total_votes',
-                    'allow_sorting_by_votes']
+    list_display = ['debate_time', 'previous_debate_time', 'show_question_votes',
+                    'show_total_votes', 'allow_sorting_by_votes']
     _fields = [f.name for f in models.SiteMode._meta.get_fields() if f.name != 'id']
     fieldsets = [
         ('General Settings', {
@@ -97,7 +97,7 @@ class SiteModeAdmin(ModelAdmin):
                        'inline_css']
         }),
         ('Debate Details', {
-            'fields': [f for f in _fields if f.startswith('debate_')],
+            'fields': [f for f in _fields if 'debate_' in f],
         }),
         ('Announcement Details', {
             'fields': [f for f in _fields if f.startswith('announcement_')],

--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -1,10 +1,11 @@
+import json
+import re
 from urllib import quote_plus
 
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.html import mark_safe
-import json
-import re
+from django.utils.timezone import now
 
 from .models import Category, Vote
 from .utils import get_voter, get_number_of_votes, vote_needs_captcha, get_site_mode
@@ -63,7 +64,10 @@ def global_vars(request):
         'ALLOW_SORTING_BY_VOTES': mode.allow_sorting_by_votes,
         'ALLOW_VOTING_AND_SUBMITTING_QUESTIONS': mode.allow_voting_and_submitting_questions,
         'DEBATE_TIME': mode.debate_time,
-        'PREVIOUS_DEBATE_TIME': mode.previous_debate_time,
+        'PREVIOUS_DEBATE_TIME': (
+            mode.previous_debate_time if mode.previous_debate_time and
+            mode.previous_debate_time < now() else None
+        ),
         'LOCAL_VOTES_STATE': mode.debate_state,
         'ANNOUNCEMENT': {
             'headline': mode.announcement_headline,

--- a/opendebates/context_processors.py
+++ b/opendebates/context_processors.py
@@ -63,6 +63,7 @@ def global_vars(request):
         'ALLOW_SORTING_BY_VOTES': mode.allow_sorting_by_votes,
         'ALLOW_VOTING_AND_SUBMITTING_QUESTIONS': mode.allow_voting_and_submitting_questions,
         'DEBATE_TIME': mode.debate_time,
+        'PREVIOUS_DEBATE_TIME': mode.previous_debate_time,
         'LOCAL_VOTES_STATE': mode.debate_state,
         'ANNOUNCEMENT': {
             'headline': mode.announcement_headline,

--- a/opendebates/forms.py
+++ b/opendebates/forms.py
@@ -236,6 +236,7 @@ class TopSubmissionForm(forms.ModelForm):
         top.headline = submission.headline
         top.followup = submission.followup
         top.votes = submission.votes
+        top.current_votes = submission.current_votes
         if commit:
             top.save()
         return top

--- a/opendebates/migrations/0032_make_current_votes_nonnullable.py
+++ b/opendebates/migrations/0032_make_current_votes_nonnullable.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0031_add_current_votes'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='current_votes',
+            field=models.IntegerField(default=0, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='topsubmission',
+            name='current_votes',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/opendebates/moderator_views.py
+++ b/opendebates/moderator_views.py
@@ -65,7 +65,7 @@ def merge(request):
             current_votes_to_merge = votes_to_merge.filter(
                 created_at__gt=previous_debate_time).count()
         else:
-            current_votes_to_merge = 0
+            current_votes_to_merge = votes_to_merge.count()
 
         local_state = get_local_votes_state()
         if local_state:

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -89,7 +89,7 @@
           </option>
           {% if PREVIOUS_DEBATE_TIME %}
           <option value="-current_votes" {% if sort == "-current_votes" %}selected{% endif %}>
-            {% blocktrans %}Top 30 Since Last Debate{% endblocktrans %}
+            {% blocktrans %}Most Votes Since Last Debate{% endblocktrans %}
           </option>
           {% endif %}
           {% if LOCAL_VOTES_STATE %}

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -87,6 +87,11 @@
           <option value="+votes" {% if sort == "+votes" %}selected{% endif %}>
             {% blocktrans %}Fewest Votes{% endblocktrans %}
           </option>
+          {% if PREVIOUS_DEBATE_TIME %}
+          <option value="-current_votes" {% if sort == "-current_votes" %}selected{% endif %}>
+            {% blocktrans %}Top 30 Since Last Debate{% endblocktrans %}
+          </option>
+          {% endif %}
           {% if LOCAL_VOTES_STATE %}
           <option value="-local_votes" {% if sort == "-local_votes" %}selected{% endif %}>
             {% blocktrans %}Most Florida Votes{% endblocktrans %}

--- a/opendebates/tests/factories.py
+++ b/opendebates/tests/factories.py
@@ -12,6 +12,13 @@ from opendebates import models
 _random = random.Random()
 
 
+class SiteModeFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.SiteMode
+
+    debate_state = 'NY'
+
+
 class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = get_user_model()
@@ -67,6 +74,7 @@ class SubmissionFactory(factory.DjangoModelFactory):
     created_at = now()
     approved = True
     votes = 1
+    current_votes = 1
 
 
 class VoteFactory(factory.DjangoModelFactory):

--- a/opendebates/tests/test_submission.py
+++ b/opendebates/tests/test_submission.py
@@ -106,9 +106,7 @@ class SubmissionTest(TestCase):
 
     def test_post_submission_after_previous_debate(self):
         mode, _ = SiteMode.objects.get_or_create()
-        mode.previous_debate_time = timezone.make_aware(
-            datetime.datetime(2016, 1, 1, 12)
-        )
+        mode.previous_debate_time = timezone.now() - datetime.timedelta(days=7)
         mode.save()
 
         self.client.post(self.url, data=self.data)

--- a/opendebates/tests/test_top_archive.py
+++ b/opendebates/tests/test_top_archive.py
@@ -37,6 +37,7 @@ class TopArchiveTest(TestCase):
         self.assertEqual(archive.headline, original_headline)
         self.assertEqual(archive.followup, idea.followup)
         self.assertEqual(archive.votes, idea.votes)
+        self.assertEqual(archive.current_votes, idea.current_votes)
 
         # These are just copies; if the underlying idea changes
         # because of additional platform use or moderator edits,
@@ -44,6 +45,7 @@ class TopArchiveTest(TestCase):
         idea.headline = "An entirely new headline"
         idea.followup = "Some totally different followup text"
         idea.votes += 1500
+        idea.current_votes += 1500
         idea.save()
 
         archive = TopSubmission.objects.get(id=id)
@@ -51,6 +53,7 @@ class TopArchiveTest(TestCase):
         self.assertEqual(archive.headline, original_headline)
         self.assertNotEqual(archive.followup, idea.followup)
         self.assertEqual(archive.votes, idea.votes - 1500)
+        self.assertEqual(archive.current_votes, idea.current_votes - 1500)
 
         # Even if the idea is deleted altogether, the archive remains.
         idea.delete()

--- a/opendebates/tests/test_utils.py
+++ b/opendebates/tests/test_utils.py
@@ -51,9 +51,7 @@ class TestUtils(TestCase):
     def test_get_previous_debate_time(self):
         self.assertIsNone(get_previous_debate_time())
 
-        previous_debate_time = timezone.make_aware(
-            datetime.datetime(2016, 1, 1, 12)
-        )
+        previous_debate_time = timezone.now() - datetime.timedelta(days=7)
         self.site_mode.previous_debate_time = previous_debate_time
         self.site_mode.save()
         self.assertEqual(get_previous_debate_time(), previous_debate_time)

--- a/opendebates/tests/test_views.py
+++ b/opendebates/tests/test_views.py
@@ -27,20 +27,26 @@ class ListIdeasTest(TestCase):
         self.client.get(self.url)
         self.assertEqual(gsm_mock.call_count, 0)
 
-    def test_top_30_not_visible_if_no_previous_debate(self):
+    def test_most_since_last_debate_not_visible_if_no_previous_debate(self):
         mode, _ = SiteMode.objects.get_or_create()
         mode.previous_debate_time = None
         mode.save()
 
         response = self.client.get(self.url)
-        self.assertNotContains(response, "Top 30 Since Last Debate")
+        self.assertNotContains(response, "Most Votes Since Last Debate")
 
-    def test_top_30_visible_if_previous_debate(self):
+    def test_most_since_last_debate_visible_if_previous_debate(self):
         mode, _ = SiteMode.objects.get_or_create()
-        mode.previous_debate_time = timezone.make_aware(
-            datetime.datetime(2016, 1, 1, 12)
-        )
+        mode.previous_debate_time = timezone.now() - datetime.timedelta(days=7)
         mode.save()
 
         response = self.client.get(self.url)
-        self.assertContains(response, "Top 30 Since Last Debate")
+        self.assertContains(response, "Most Votes Since Last Debate")
+
+    def test_most_since_last_debate_visible_if_previous_debate_in_future(self):
+        mode, _ = SiteMode.objects.get_or_create()
+        mode.previous_debate_time = timezone.now() + datetime.timedelta(days=7)
+        mode.save()
+
+        response = self.client.get(self.url)
+        self.assertNotContains(response, "Most Votes Since Last Debate")

--- a/opendebates/tests/test_views.py
+++ b/opendebates/tests/test_views.py
@@ -1,8 +1,11 @@
+import datetime
 import mock
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.utils import timezone
 
+from ..models import SiteMode
 from .factories import SubmissionFactory
 
 
@@ -23,3 +26,21 @@ class ListIdeasTest(TestCase):
         """
         self.client.get(self.url)
         self.assertEqual(gsm_mock.call_count, 0)
+
+    def test_top_30_not_visible_if_no_previous_debate(self):
+        mode, _ = SiteMode.objects.get_or_create()
+        mode.previous_debate_time = None
+        mode.save()
+
+        response = self.client.get(self.url)
+        self.assertNotContains(response, "Top 30 Since Last Debate")
+
+    def test_top_30_visible_if_previous_debate(self):
+        mode, _ = SiteMode.objects.get_or_create()
+        mode.previous_debate_time = timezone.make_aware(
+            datetime.datetime(2016, 1, 1, 12)
+        )
+        mode.save()
+
+        response = self.client.get(self.url)
+        self.assertContains(response, "Top 30 Since Last Debate")

--- a/opendebates/tests/test_vote.py
+++ b/opendebates/tests/test_vote.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 import os
 
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from opendebates.models import Submission, Vote, Voter, SiteMode, ZipCode
 from .factories import UserFactory, SubmissionFactory, VoterFactory, VoteFactory
@@ -15,6 +17,7 @@ class VoteTest(TestCase):
         self.submission_url = self.submission.get_absolute_url()
         # keep track of vote count before test starts
         self.votes = self.submission.votes
+        self.current_votes = self.submission.current_votes
         password = 'secretPassword'
         self.user = UserFactory(password=password)
         self.voter = VoterFactory(user=self.user, email=self.user.email)
@@ -81,6 +84,7 @@ class VoteTest(TestCase):
         # .. and in the database
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
 
     def test_vote_local_voter(self):
         mode, _ = SiteMode.objects.get_or_create()
@@ -100,6 +104,7 @@ class VoteTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
         self.assertEqual(1, refetched_sub.local_votes)
 
     def test_vote_nonlocal_voter(self):
@@ -120,6 +125,7 @@ class VoteTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
         self.assertEqual(0, refetched_sub.local_votes)
 
     def test_vote_no_local_district_configured(self):
@@ -141,6 +147,7 @@ class VoteTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
         self.assertEqual(0, refetched_sub.local_votes)
 
     def test_vote_anon_new_voter_source(self):
@@ -211,8 +218,9 @@ class VoteTest(TestCase):
         json_rsp = json.loads(rsp.content)
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         # votes is not incremented (in JSON response or in DB)
-        self.assertEqual(self.votes + 0, json_rsp['tally'])
-        self.assertEqual(self.votes + 0, refetched_sub.votes)
+        self.assertEqual(self.votes, json_rsp['tally'])
+        self.assertEqual(self.votes, refetched_sub.votes)
+        self.assertEqual(self.current_votes, refetched_sub.current_votes)
 
     def test_anon_can_use_other_users_account(self):
         "Unauthenticated can use an authenticated user's account."
@@ -228,6 +236,7 @@ class VoteTest(TestCase):
         # votes is incremented
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
 
     def test_vote_user(self):
         "Authenticated user can vote."
@@ -245,6 +254,7 @@ class VoteTest(TestCase):
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         # ... and in DB
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
 
     def test_vote_twice_user(self):
         "Authenticated user can only vote once."
@@ -259,10 +269,11 @@ class VoteTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         json_rsp = json.loads(rsp.content)
         # vote is not incremented in JSON response
-        self.assertEqual(self.votes + 0, json_rsp['tally'])
+        self.assertEqual(self.votes, json_rsp['tally'])
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         # ... or in the DB
-        self.assertEqual(self.votes + 0, refetched_sub.votes)
+        self.assertEqual(self.votes, refetched_sub.votes)
+        self.assertEqual(self.current_votes, refetched_sub.current_votes)
 
     def test_vote_user_bad_captcha(self):
         # If captcha doesn't pass, no vote
@@ -277,6 +288,7 @@ class VoteTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         self.assertEqual(self.votes, refetched_sub.votes)
+        self.assertEqual(self.current_votes, refetched_sub.current_votes)
 
     @override_settings(USE_CAPTCHA=False)
     def test_vote_user_disabled_captcha(self):
@@ -294,6 +306,53 @@ class VoteTest(TestCase):
         refetched_sub = Submission.objects.get(pk=self.submission.pk)
         # ... and in DB
         self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
+
+    def test_vote_after_previous_debate(self):
+        "Votes after the previous debate get tracked separately."
+        mode, _ = SiteMode.objects.get_or_create()
+        mode.previous_debate_time = timezone.make_aware(
+            datetime.datetime(2016, 1, 1, 12)
+        )
+        mode.save()
+
+        data = {
+            'email': self.voter.email,
+            'zipcode': self.voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }
+        rsp = self.client.post(self.submission_url, data=data,
+                               HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, rsp.status_code)
+        json_rsp = json.loads(rsp.content)
+        # vote is incremented in JSON response
+        self.assertEqual(self.votes + 1, json_rsp['tally'])
+        refetched_sub = Submission.objects.get(pk=self.submission.pk)
+        # ... and in DB
+        self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes + 1, refetched_sub.current_votes)
+
+    def test_vote_before_previous_debate(self):
+        "Votes before the previous debate don't get tracked yet."
+        mode, _ = SiteMode.objects.get_or_create()
+        mode.previous_debate_time = timezone.now() + datetime.timedelta(days=1)
+        mode.save()
+
+        data = {
+            'email': self.voter.email,
+            'zipcode': self.voter.zip,
+            'g-recaptcha-response': 'PASSED'
+        }
+        rsp = self.client.post(self.submission_url, data=data,
+                               HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, rsp.status_code)
+        json_rsp = json.loads(rsp.content)
+        # vote is incremented in JSON response
+        self.assertEqual(self.votes + 1, json_rsp['tally'])
+        refetched_sub = Submission.objects.get(pk=self.submission.pk)
+        # ... and in DB
+        self.assertEqual(self.votes + 1, refetched_sub.votes)
+        self.assertEqual(self.current_votes, refetched_sub.current_votes)
 
     # non AJAX tests
 

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -131,10 +131,8 @@ def sort_list(citations_only, sort, ideas):
         ideas = ideas.order_by("votes")
     elif sort == "-local_votes":
         ideas = ideas.order_by("-local_votes")
-    elif sort == "+current_votes":
-        ideas = ideas.order_by("current_votes")
     elif sort == "-current_votes":
-        ideas = ideas.order_by("-current_votes")
+        ideas = ideas.order_by("-current_votes")[:30]
 
     return ideas
 

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -132,7 +132,7 @@ def sort_list(citations_only, sort, ideas):
     elif sort == "-local_votes":
         ideas = ideas.order_by("-local_votes")
     elif sort == "-current_votes":
-        ideas = ideas.order_by("-current_votes")[:30]
+        ideas = ideas.order_by("-current_votes")
 
     return ideas
 

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -131,6 +131,10 @@ def sort_list(citations_only, sort, ideas):
         ideas = ideas.order_by("votes")
     elif sort == "-local_votes":
         ideas = ideas.order_by("-local_votes")
+    elif sort == "+current_votes":
+        ideas = ideas.order_by("current_votes")
+    elif sort == "-current_votes":
+        ideas = ideas.order_by("-current_votes")
 
     return ideas
 
@@ -157,3 +161,7 @@ def allow_voting_and_submitting_questions():
 
 def get_local_votes_state():
     return get_site_mode().debate_state
+
+
+def get_previous_debate_time():
+    return get_site_mode().previous_debate_time

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -21,7 +21,7 @@ from .models import Candidate, Category, Flag, Submission, \
 from .router import readonly_db
 from .utils import get_ip_address_from_request, get_headers_from_request, choose_sort, sort_list, \
     vote_needs_captcha, registration_needs_captcha, show_question_votes, \
-    allow_voting_and_submitting_questions, get_local_votes_state
+    allow_voting_and_submitting_questions, get_local_votes_state, get_previous_debate_time
 # from opendebates_comments.forms import CommentForm
 from opendebates_emails.models import send_email
 
@@ -246,10 +246,15 @@ def vote(request, id):
 
         )
     )
+    previous_debate_time = get_previous_debate_time()
     if created:
         # update the DB with the real tally
         Submission.objects.filter(id=id).update(
             votes=F('votes')+1,
+            current_votes=F('current_votes')+(
+                1 if previous_debate_time is None or vote.created_at > previous_debate_time
+                else 0
+            ),
             local_votes=F('local_votes')+(
                 1 if voter.state and voter.state == get_local_votes_state()
                 else 0)
@@ -313,6 +318,7 @@ def questions(request):
         )
     )
 
+    previous_debate_time = get_previous_debate_time()
     idea = Submission.objects.create(
         voter=voter,
         category_id=category,
@@ -324,6 +330,8 @@ def questions(request):
         ip_address=get_ip_address_from_request(request),
         approved=True,
         votes=1,
+        current_votes=(1 if previous_debate_time is None or vote.created_at > previous_debate_time
+                       else 0),
         local_votes=1 if voter.state and voter.state == get_local_votes_state() else 0,
         source=request.COOKIES.get('opendebates.source'),
     )

--- a/opendebates/views.py
+++ b/opendebates/views.py
@@ -319,6 +319,7 @@ def questions(request):
     )
 
     previous_debate_time = get_previous_debate_time()
+    created_at = timezone.now()
     idea = Submission.objects.create(
         voter=voter,
         category_id=category,
@@ -326,11 +327,11 @@ def questions(request):
         followup=form_data['question'],
         idea=(u'%s %s' % (form_data['headline'], form_data['question'])).strip(),
         citation=form_data['citation'],
-        created_at=timezone.now(),
+        created_at=created_at,
         ip_address=get_ip_address_from_request(request),
         approved=True,
         votes=1,
-        current_votes=(1 if previous_debate_time is None or vote.created_at > previous_debate_time
+        current_votes=(1 if previous_debate_time is None or created_at > previous_debate_time
                        else 0),
         local_votes=1 if voter.state and voter.state == get_local_votes_state() else 0,
         source=request.COOKIES.get('opendebates.source'),
@@ -342,7 +343,7 @@ def questions(request):
         source=idea.source,
         ip_address=get_ip_address_from_request(request),
         request_headers=get_headers_from_request(request),
-        created_at=timezone.now())
+        created_at=created_at)
 
     send_email("submitted_new_idea", {"idea": idea})
     send_email("notify_moderators_submitted_new_idea", {"idea": idea})


### PR DESCRIPTION
OP-173

Still to do:
- [x] add the entries to the form for sorting by `current_votes`
- [x] write the tests
