### PR TITLE
Update django-debug-toolbar

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-endless-pagination==2.0
 django-dotenv==1.4.1
 djangohelpers==0.18.1
 djorm-ext-pgfulltext==0.9.3
-django-debug-toolbar==1.4.0
+django-debug-toolbar==1.5
 django-pipeline==1.5.4
 django-bower==5.0.4
 django-bootstrap-form==3.1


### PR DESCRIPTION
Version 1.4 led to an error:

TypeError at /
process() takes exactly 3 arguments (2 given)
