### PR TITLE
Upgrade kombu

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ newrelic==2.44.0.36
 
 django-celery==3.1.17
 Celery==3.1.18
-kombu==3.0.26
+kombu==3.0.30
 amqp==1.4.6
 
 django-dbbackup==2.4.1


### PR DESCRIPTION
I was getting this error when running migrate:

```
Traceback (most recent call last):
  File "manage.py", line 20, in <module>
    execute_from_command_line(sys.argv)
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 303, in execute
    settings.INSTALLED_APPS
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/django/conf/__init__.py", line 44, in _setup
    self._wrapped = Settings(settings_module)
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/django/conf/__init__.py", line 92, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/vkurup/dev/django-opendebates/opendebates/__init__.py", line 5, in <module>
    from .celery import app as celery_app  # noqa
  File "/home/vkurup/dev/django-opendebates/opendebates/celery.py", line 6, in <module>
    from celery import Celery
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/celery/__init__.py", line 130, in <module>
    from celery import five
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/celery/five.py", line 149, in <module>
    from kombu.utils.compat import OrderedDict  # noqa
  File "/home/vkurup/.virtualenvs/opendebates/local/lib/python2.7/site-packages/kombu/utils/__init__.py", line 19, in <module>
    from uuid import UUID, uuid4 as _uuid4, _uuid_generate_random
ImportError: cannot import name _uuid_generate_random
```

Upgrading kombu fixes it.
