### PR TITLE
Add hardcoded "no naming candidates" language

### DIFF
--- a/opendebates/static/less/base.less
+++ b/opendebates/static/less/base.less
@@ -1930,3 +1930,15 @@ nav ul.pagination:after {
     }
   }
 }
+
+.no-naming-candidates {
+  display: block;
+  max-width: 80%;
+  margin: 0 auto;
+  text-align: center;
+  font-size: 12px;
+
+  .emphasis {
+    color: @brand-tertiary;
+  }
+}

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -10,7 +10,7 @@
   <input type="submit" value=""/>
   <div class="search-ctn">
     <input name="q" class="form-control" id="search-full"
-           placeholder="{% if ALLOW_VOTING_AND_SUBMITTING_QUESTIONS %}{% blocktrans %}Before submitting your own question, search keywords to see if it was already asked{% endblocktrans %}{% else %}{% blocktrans %}Search questions by keyword{% endblocktrans %}{% endif %}"
+           placeholder="{% if ALLOW_VOTING_AND_SUBMITTING_QUESTIONS %}{% blocktrans %}Before submitting your own question, search keywords to see if it was already asked. (No naming candidates. Both candidates must be able to answer questions.){% endblocktrans %}{% else %}{% blocktrans %}Search questions by keyword{% endblocktrans %}{% endif %}"
            value="{{ search_term|default:'' }}" onkeyup="javascript:if(arguments[0].keyCode===13)this.form.submit();">
   </div>
   <div class="search-ctn">

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -90,5 +90,6 @@
       </fieldset>
     </form>
   </div>
+  <small class="no-naming-candidates"><span class="emphasis">No naming candidates.</span> Both candidates must be able to answer.</small>
 </div>
 {% endif %}


### PR DESCRIPTION
For the sake of being able to deploy this ASAP without any database migrations or downtime, I hardcoded the language.  In the future I should circle back to this somehow and make it configurable.
