### PR TITLE
Bulk Removal of submissions via admin search

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -1,9 +1,11 @@
 import itertools
 
 from django.contrib.admin import ModelAdmin, register
+from django.shortcuts import render
 from djangohelpers.export_action import admin_list_export
 
 from . import models
+from opendebates_emails.models import send_email
 
 
 @register(models.Category)
@@ -15,8 +17,32 @@ class CategoryAdmin(ModelAdmin):
 @register(models.Submission)
 class SubmissionAdmin(ModelAdmin):
     list_display = [f.name for f in models.Submission._meta.fields]
-    actions = [admin_list_export]
+    list_filter = ('approved', )
+    search_fields = ('idea', )
+    actions = [admin_list_export, 'remove_submissions']
     raw_id_fields = ['voter', 'duplicate_of']
+
+    def remove_submissions(self, request, queryset):
+        "Custom action to mark submissions 'unapproved' and to notify users by email."
+        if request.POST.get('post'):
+            count = 0
+            # only email user if submission changes status, hence the filter
+            for submission in queryset.filter(approved=True):
+                count += 1
+                submission.approved = False
+                submission.moderated_removal = True
+                submission.removal_flags.all().update(reviewed=True)
+                submission.save()
+                send_email("idea_is_removed", {"idea": submission})
+            if count == 1:
+                msg = "Removed 1 submission"
+            else:
+                msg = "Removed {} submissions".format(count)
+            self.message_user(request, msg)
+            return None  # returning None causes us to return to changelist
+        context = {'queryset': queryset}
+        return render(request, 'opendebates/admin/remove_submissions.html', context)
+    remove_submissions.short_description = 'Remove selected submissions'
 
 
 @register(models.Voter)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -44,6 +44,13 @@ class SubmissionAdmin(ModelAdmin):
         return render(request, 'opendebates/admin/remove_submissions.html', context)
     remove_submissions.short_description = 'Remove selected submissions'
 
+    def get_actions(self, request):
+        # Remove the default 'Delete selected...' action
+        actions = super(SubmissionAdmin, self).get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
+
 
 @register(models.Voter)
 class VoterAdmin(ModelAdmin):

--- a/opendebates/settings.py
+++ b/opendebates/settings.py
@@ -183,6 +183,13 @@ STATICFILES_FINDERS = (
     'djangobower.finders.BowerFinder',
 )
 
+if TEST:
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+    STATICFILES_FINDERS = (
+        'django.contrib.staticfiles.finders.FileSystemFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    )
+
 PIPELINE_COMPILERS = (
     'pipeline.compilers.less.LessCompiler',
 )

--- a/opendebates/templates/opendebates/admin/remove_submissions.html
+++ b/opendebates/templates/opendebates/admin/remove_submissions.html
@@ -1,0 +1,29 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+  <p>
+    These submissions will be marked "unapproved" and will not show up on the
+    live site. An email will be sent to notify the submitter. Are you sure you
+    want to remove the selected submissions?
+  </p>
+
+  <h2>Submissions</h2>
+
+  <ul>
+  {% for submission in queryset %}
+    <li>&lt;ID {{ submission.pk }}&gt;: {{ submission.idea }}</li>
+  {% endfor %}
+  </ul>
+
+  <form action="" method="post">{% csrf_token %}
+    <div>
+      {% for obj in queryset %}
+        <input type="hidden" name="_selected_action" value="{{ obj.pk }}" />
+      {% endfor %}
+      <input type="hidden" name="action" value="remove_submissions" />
+    <input type="hidden" name="post" value="yes" />
+    <input type="submit" value="Yes, I'm sure" />
+    <a href="#" onclick="window.history.back(); return false;" class="button cancel-link">No, take me back</a>
+    </div>
+  </form>
+{% endblock %}

--- a/opendebates/tests/test_admin.py
+++ b/opendebates/tests/test_admin.py
@@ -1,0 +1,102 @@
+from django.contrib.admin.sites import AdminSite
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from mock import patch
+
+from opendebates.admin import SubmissionAdmin
+from opendebates.models import Submission
+from opendebates.tests.factories import SubmissionFactory, UserFactory
+
+
+# mock objects to make the admin think we're superusers.
+# mostly copied from
+# https://github.com/django/django/blob/master/tests/modeladmin/tests.py#L23-L32
+
+class MockRequest(object):
+    POST = {}
+    META = {}
+
+
+class MockSuperUser(object):
+    def has_perm(self, perm):
+        return True
+
+    def is_authenticated(self):
+        return True
+
+request = MockRequest()
+request.user = MockSuperUser()
+
+
+class RemoveSubmissionsTest(TestCase):
+
+    def setUp(self):
+        self.site = AdminSite()
+        self.admin = SubmissionAdmin(Submission, self.site)
+        self.password = 'secretpassword'
+        self.user = UserFactory(password=self.password, is_staff=True, is_superuser=True)
+        assert self.client.login(username=self.user.username, password=self.password)
+        self.submission = SubmissionFactory()
+        self.queryset = Submission.objects.all()
+        self.changelist_url = reverse('admin:opendebates_submission_changelist')
+
+    def test_get(self):
+        """
+        GETting the intermediate page should have specified text and the PK of
+        the chosen submissions.
+        """
+        rsp = self.admin.remove_submissions(request, self.queryset)
+        self.assertEqual(rsp.status_code, 200)
+        self.assertContains(rsp, 'remove the selected submissions?')
+        self.assertContains(rsp, self.submission.pk)
+
+    @patch('opendebates.admin.send_email')
+    def test_post(self, mock_send_email):
+        """
+        POSTing the form should cause submissions to be removed and email to be
+        sent.
+        """
+        data = {
+            'post': 'Yes',
+            'action': 'remove_submissions',
+            '_selected_action': [self.submission.pk, ]
+        }
+        rsp = self.client.post(self.changelist_url, data=data)
+        self.assertRedirects(rsp, self.changelist_url)
+        # Now submission should not be approved
+        submission = Submission.objects.get()
+        self.assertFalse(submission.approved)
+        # and 1 email should have been sent
+        self.assertEqual(mock_send_email.call_count, 1)
+
+    @patch('opendebates.admin.send_email')
+    def test_post_multiple(self, mock_send_email):
+        "POSTing multiple submissions works as well."
+        data = {
+            'post': 'Yes',
+            'action': 'remove_submissions',
+            '_selected_action': [SubmissionFactory().pk, SubmissionFactory().pk]
+        }
+        rsp = self.client.post(self.changelist_url, data=data)
+        self.assertRedirects(rsp, self.changelist_url)
+        removed_submissions = Submission.objects.filter(approved=False)
+        self.assertEqual(removed_submissions.count(), 2)
+        untouched_submission = Submission.objects.filter(approved=True)
+        self.assertEqual(untouched_submission.count(), 1)
+        # and 2 emails have been sent
+        self.assertEqual(mock_send_email.call_count, 2)
+
+    @patch('opendebates.admin.send_email')
+    def test_dont_send_email_if_already_unapproved(self, mock_send_email):
+        "If submission was already unapproved, don't bug the user again."
+        data = {
+            'post': 'Yes',
+            'action': 'remove_submissions',
+            '_selected_action': [SubmissionFactory(approved=False).pk]
+        }
+        rsp = self.client.post(self.changelist_url, data=data)
+        self.assertRedirects(rsp, self.changelist_url)
+        removed_submissions = Submission.objects.filter(approved=False)
+        self.assertEqual(removed_submissions.count(), 1)
+        # and ZERO emails have been sent
+        self.assertEqual(mock_send_email.call_count, 0)


### PR DESCRIPTION
This:
- adds a `list_filter` to make it easier for admins to only start with 'approved' submissions
- adds a `search_fields` setting to allow admins to search for any text in the `idea` column. (Note, the headline and followup fields are merged into the idea field during normal (non-admin) form submission)
- adds a custom action to allow 'removal' of submissions chosen via checkbox (after a confirmation page)
- emails the original user about the change, but only if it really was a change. If original submission was already unapproved, no email is sent.
- is based on code stolen from Django's `delete_selected` action.

My choice of the label for the dropdown is "Remove selected submissions", which is confusingly similar to "Delete selected submissions", but I couldn't think of a better, not-too-long name. Ideas? Or maybe we should remove the `delete_selected` action to prevent confusion?
