### PR TITLE
When viewing search results, sort form should preserve search

### DIFF
--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -9,9 +9,10 @@
 <form action="{% url 'search_ideas' %}" method="GET" id="top-search">
   <input type="submit" value=""/>
   <div class="search-ctn">
-    <input name="q" class="form-control" id="search-full"
+    <input name="q" value="{{ search_term|default:'' }}"
+           class="form-control" id="search-full"
            placeholder="{% if ALLOW_VOTING_AND_SUBMITTING_QUESTIONS %}{% blocktrans %}Before submitting your own question, search keywords to see if it was already asked. (No naming candidates. Both candidates must be able to answer questions.){% endblocktrans %}{% else %}{% blocktrans %}Search questions by keyword{% endblocktrans %}{% endif %}"
-           value="{{ search_term|default:'' }}" onkeyup="javascript:if(arguments[0].keyCode===13)this.form.submit();">
+           onkeyup="javascript:if(arguments[0].keyCode===13)this.form.submit();">
   </div>
   <div class="search-ctn">
     <input name="q" class="form-control" id="search-small"
@@ -54,6 +55,11 @@
   {% cache 30 list_ideas_content sort url_name search_term category.id %}
     <div class="sort-column">
       <form action="{{ url_name }}" method="GET" class="form-inline">
+
+        {% if search_term %}
+        <input type="hidden" name="q" value="{{ search_term }}">
+        {% endif %}
+
         <label for="q">
           {% blocktrans %}Sort questions by{% endblocktrans %}
         </label>

--- a/opendebates/tests/test_navigation.py
+++ b/opendebates/tests/test_navigation.py
@@ -1,0 +1,53 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+import re
+
+from .factories import SubmissionFactory
+
+
+@override_settings(SUBMISSIONS_PER_PAGE=2)
+class NavigationTest(TestCase):
+
+    def setUp(self):
+        self.url = reverse('list_ideas')
+        self.search_url = reverse('search_ideas')
+
+        SubmissionFactory(votes=1)
+        SubmissionFactory(votes=2)
+        SubmissionFactory(headline="Something about ducks", votes=10)
+        SubmissionFactory(headline="Another thing about ducks", votes=5)
+
+    def find_first_page_link(self, content):
+        link = re.search('<a\W+href="(.*)"\W+rel="page"\W+class="endless_page_link">2</a>',
+                         content)
+        self.assertNotEqual(None, link)
+        return link.groups()[0]
+
+    def test_sort_by_option_is_sticky(self):
+        rsp = self.client.get(self.url + '?sort=%2Bvotes')
+        # Make sure it's actually sorting properly
+        self.assertNotContains(rsp, 'ducks')
+        self.assertNotContains(rsp, '<option value="-votes" selected>')
+        self.assertContains(rsp, '<option value="+votes" selected>')
+
+        rsp = self.client.get(self.url + '?sort=-votes')
+        # Make sure it's actually sorting properly
+        self.assertContains(rsp, 'ducks')
+        self.assertContains(rsp, '<option value="-votes" selected>')
+
+    def test_search_term_is_sticky(self):
+        rsp = self.client.get(self.search_url + "?q=something+ducks")
+        # Make sure it's actually searching properly
+        self.assertContains(rsp, 'ducks')
+        self.assertContains(rsp, '<input name="q" value="something ducks"')
+
+    def test_search_term_inserts_into_sort_form(self):
+        rsp = self.client.get(self.search_url + "?q=something+ducks")
+        form_html = ('\<form action="{search}" method="GET" '
+                     'class="form-inline"\>\W+'
+                     '\<input type="hidden" name="q" '
+                     'value="something ducks"\>'.format(
+                         search=self.search_url))
+        self.assertNotEqual(None, re.search(form_html, rsp.content))

--- a/opendebates/tests/test_navigation.py
+++ b/opendebates/tests/test_navigation.py
@@ -19,12 +19,6 @@ class NavigationTest(TestCase):
         SubmissionFactory(headline="Something about ducks", votes=10)
         SubmissionFactory(headline="Another thing about ducks", votes=5)
 
-    def find_first_page_link(self, content):
-        link = re.search('<a\W+href="(.*)"\W+rel="page"\W+class="endless_page_link">2</a>',
-                         content)
-        self.assertNotEqual(None, link)
-        return link.groups()[0]
-
     def test_sort_by_option_is_sticky(self):
         rsp = self.client.get(self.url + '?sort=%2Bvotes')
         # Make sure it's actually sorting properly


### PR DESCRIPTION
Previously, using the sort options on a `/search/?q=something` page would wipe out the search term and redirect you back to the main list_ideas view, sorted. This made it impossible to sort your search results.
