### PR TITLE
Increase max length of Voter.source

### DIFF
--- a/opendebates/migrations/0031_auto_20160928_2107.py
+++ b/opendebates/migrations/0031_auto_20160928_2107.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0030_auto_20160927_1242'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='voter',
+            name='source',
+            field=models.CharField(max_length=4096, null=True, blank=True),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -283,7 +283,7 @@ class Voter(models.Model):
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL, null=True, blank=True, related_name="voter")
 
-    source = models.CharField(max_length=255, null=True, blank=True)
+    source = models.CharField(max_length=4096, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     display_name = models.CharField(max_length=255, null=True, blank=True)


### PR DESCRIPTION
Length of source field that just came in was 951 characters. This PR increases it to at least 4 times that value. Should be safe to deploy without downtime since field is nullable to begin with.

```
Internal Server Error: /questions/5848/vote/
Traceback (most recent call last):
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/newrelic-2.44.0.36/newrelic/hooks/framework_django.py", line 497, in
 wrapper
    return wrapped(*args, **kwargs)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/djangohelpers/lib.py", line 22, in rendered_func
    response = func(request, *args, **kwargs)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/djangohelpers/lib.py", line 48, in inner
    return func(request, *args, **kwargs)
  File "/home/opendebates/www/presidential/code_root/opendebates/views.py",
 line 229, in vote
    user=request.user if request.user.is_authenticated() else None,
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/query.py", line 407, in get_or_create
    return self._create_object_from_params(lookup, params)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/query.py", line 439, in _create_object_from_params
    obj = self.create(**params)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/query.py", line 348, in create
    obj.save(force_insert=True, using=self.db)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 734, in save
    force_update=force_update, update_fields=update_fields)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 762, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using,
 update_fields)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 846, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk,
 raw)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 885, in _do_insert
    using=using, raw=raw)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/query.py", line 920, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 974, in execute_sql
    cursor.execute(sql, params)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File
 "/home/opendebates/www/presidential/env/local/lib/python2.7/site-packages/newrelic-2.44.0.36/newrelic/hooks/database_dbapi2.py", line 22, in
 execute
    *args, **kwargs)
DataError: value too long for type character varying(255)


Request repr():
<WSGIRequest
path:/questions/5848/vote/,
GET:<QueryDict: {}>,
POST:<QueryDict: {u'csrfmiddlewaretoken':
 [u'EKO0rBrbcfDFmEOnBuchdnPyLPzIU1EU'], u'g-recaptcha-response':
 [u'03AHJ_VuvFDQlymcB75h7bLMBFvUUXinvHDX3ccnJaes0-V_2g1luTA7waUOxiHmRBafEHq6Byu83qg8dEU3ME7xb4vM677h8BPZdXnWXdVuU1_fXnkQl9O5Fbbkmsn52uSH09jJzq859sENsE4HMVL0YWWN2iQ1TEQQcgcgtQ4ICbzJOSYIlvXi-vvp3_IgK-zPuE7oYo35t25uIW9FZqaKfbhv_uat2dM9B-SPYpieyVF24eIA5vDEKbJyBSvS2WmRJduzkXryHRQ6KEUvL4zl17nMLsCfVL7jyLfjiJA8-1zmJoT8zCtjvcJUl5fPhK-qWWn7yZDKZ81KDmy4FzdpP6ppePioD-vwMdnD3X2-mYZfJe1qmg4OU3Z_3hlVWmYmvSchxxpeM6EkPi9q64aZ7Y5cvIDK1M9SA41OJQKe9_mx_5zttMqP0H2UKI86pwrMlhrYhBVZ7_cGVe5MQ-Y4TC5Z0zbOaUx5IhTO-ueo05IPXH5Ozx-EvGl81k8NfJQ59lkwzW-Og7IOZ1zI9KYXW-qT0czWhHkWrOHED_ggvlkqN9zz1XCg9DZSLmOMcLN-I2wWWu7RTeEMuHNQLYKR_4vKO1X1ntX0mvD7a8dSdaIlTWfTZayoj3cQW3OAV25NlzyISHco0rjY7dWwUGRStOWTX6ELMHPvQf87nD_6Fmn1EL_VJxROv72KgY_CUfqTv0ct6p74MnavV8sSFN3rT8EwWM46EU7Ulo17xrBamC92i52HPenH-JWdfSqXPX1FvYAqtLjbhm15GXGihzXHTECXrcRhcnkqaeIeosur_X_YojWBtmcWXLdgpbAlXVjTz431uqvdQ5eimvLbdLPTbImD69w_-O9eYzzvWkqgSWzqNSPgY8OrT
 RGZaVK9eD8Q8n1BFAtITtbptZrQVCksg3H0zupA0YjFWHW4ueypYODyoeMLqGVA5vwoP3JA_PbPh1BRQ6ghrIpBdseW5gi9c26sF_hgGdxZ4vHWjNOItlcPb3Zm5fiJZ0cUqEpgm2c9i20Wt9duZsr4FSMgdwj65gp3Cx6u6-xUZF-iDzBNyZ5hC3eoM-w4KNYBEK--Rytpy4zK3Y9dvAEcFbq6ciSilGWt2TLTk7FfwKUtbj_Ypnlqc4VUouUqlal01HIEDm8AKG2wxkaGhx'],
 u'email': [u'sumami3246@comcast.net'], u'zipcode': [u'32225']}>,
COOKIES:{'__cfduid': 'd7ce5a61e3e2d5f8241c32d6e5b62d90d1475109564',
 'csrftoken': 'EKO0rBrbcfDFmEOnBuchdnPyLPzIU1EU',
 'mp_70007c46cc216494def71244d3d3c782_mixpanel':
 '%7B%22distinct_id%22%3A%20%221577361c49a1f7-0833640fc-1648606b-2c600-1577361c49c165%22%2C%22%24initial_referrer%22%3A%20%22http%3A%2F%2Fm.facebook.com%22%2C%22%24initial_referring_domain%22%3A%20%22m.facebook.com%22%7D',
 'mp_mixpanel__c': '10',
 'opendebates.source':
 "share-fb-5848Add%20photosChoose%20FilesTag%20peopleAdd%20what%20you're%20doing%20or%20how%20you're%20feelingTag%20a%20locationMagnolia%20Admin%20GroupPostPINNED%20POSTNews%20FeedChance%20Ashman-GallikerSeptember%2019%20at%205%3A35pmThe%20weather%20will%20be%20turning%20cold%20soon%20so%20we're%20offering%20our%20long-sleeved%20tee-shirts%20and%20sweatshirts.%20We've%20done%20a%20little%20re-designing%20on%20the%20back%20of%20the%20shirt%2C%20so%20be%20sure%20to%20check%20it%20out.Help%20us%20raise%20awareness%20about%20addiction%20as%20well%20as%20offer%20support%20for%20families.Creating%20opportunities%20for%20Recovery!BOOSTER.COM5%20Comments19%20SharesSeen%20by%20233%20Amy%20Tompkins%20Albanese%2C%20Dina%20DiDario%20and%20Audrey%20PorterLikeLikeLoveHahaWowSadAngryCommentShareNews%20FeedRECENT%20ACTIVITYKatrin%20O'Leary%20commented%20on%20this%20post.Audrey%20PorterYesterday%20at%207%3A46pmEngaging%20Campuses%20to%20Help%20Americans%20",
 'optimizelyBuckets': '%7B%7D',
 'optimizelyEndUserId': 'oeu1475109568822r0.5033269170671701',
 'optimizelySegments':
 '%7B%227455220047%22%3A%22unknown%22%2C%227444100147%22%3A%22referral%22%2C%227424281795%22%3A%22true%22%7D'},
META:{'CONTENT_LENGTH': '1285',
 'CONTENT_TYPE': 'application/x-www-form-urlencoded; charset=UTF-8',
 u'CSRF_COOKIE': u'EKO0rBrbcfDFmEOnBuchdnPyLPzIU1EU',
 'HTTP_ACCEPT': '*/*',
 'HTTP_ACCEPT_ENCODING': 'gzip',
 'HTTP_ACCEPT_LANGUAGE': 'en-us',
 'HTTP_CF_CONNECTING_IP': '66.87.148.22',
 'HTTP_CF_IPCOUNTRY': 'US',
 'HTTP_CF_RAY': '2e9b631a1d6e5290-MIA',
 'HTTP_CF_VISITOR': '{"scheme":"https"}',
 'HTTP_CONNECTION': 'close',
 'HTTP_COOKIE': "__cfduid=d7ce5a61e3e2d5f8241c32d6e5b62d90d1475109564;
 mp_70007c46cc216494def71244d3d3c782_mixpanel=%7B%22distinct_id%22%3A%20%221577361c49a1f7-0833640fc-1648606b-2c600-1577361c49c165%22%2C%22%24initial_referrer%22%3A%20%22http%3A%2F%2Fm.facebook.com%22%2C%22%24initial_referring_domain%22%3A%20%22m.facebook.com%22%7D;
 mp_mixpanel__c=10; optimizelyBuckets=%7B%7D;
 optimizelyEndUserId=oeu1475109568822r0.5033269170671701;
 optimizelySegments=%7B%227455220047%22%3A%22unknown%22%2C%227444100147%22%3A%22referral%22%2C%227424281795%22%3A%22true%22%7D;
 csrftoken=EKO0rBrbcfDFmEOnBuchdnPyLPzIU1EU;
 opendebates.source=share-fb-5848Add%20photosChoose%20FilesTag%20peopleAdd%20what%20you're%20doing%20or%20how%20you're%20feelingTag%20a%20locationMagnolia%20Admin%20GroupPostPINNED%20POSTNews%20FeedChance%20Ashman-GallikerSeptember%2019%20at%205%3A35pmThe%20weather%20will%20be%20turning%20cold%20soon%20so%20we're%20offering%20our%20long-sleeved%20tee-shirts%20and%20sweatshirts.%20We've%2
 0done%20a%20little%20re-designing%20on%20the%20back%20of%20the%20shirt%2C%20so%20be%20sure%20to%20check%20it%20out.Help%20us%20raise%20awareness%20about%20addiction%20as%20well%20as%20offer%20support%20for%20families.Creating%20opportunities%20for%20Recovery!BOOSTER.COM5%20Comments19%20SharesSeen%20by%20233%20Amy%20Tompkins%20Albanese%2C%20Dina%20DiDario%20and%20Audrey%20PorterLikeLikeLoveHahaWowSadAngryCommentShareNews%20FeedRECENT%20ACTIVITYKatrin%20O'Leary%20commented%20on%20this%20post.Audrey%20PorterYesterday%20at%207%3A46pmEngaging%20Campuses%20to%20Help%20Americans%20",
 'HTTP_HOST': 'presidentialopenquestions.com',
 'HTTP_ORIGIN': 'https://presidentialopenquestions.com',
 'HTTP_REFERER':
 'https://presidentialopenquestions.com/questions/5848/vote/?source=share-fb-5848Add+photosChoose+FilesTag+peopleAdd+what+you%27re+doing+or+how+you%27re+feelingTag+a+locationMagnolia+Admin+GroupPostPINNED+POSTNews+FeedChance+Ashman-GallikerSeptember+19+at+5%3A35pmThe+weather+will+be+turning+cold+soon+so+we%27re+offering+our+long-sleeved+tee-shirts+and+sweatshirts.+We%27ve+done+a+little+re-designing+on+the+back+of+the+shirt%2C+so+be+sure+to+check+it+out.Help+us+raise+awareness+about+addiction+as+well+as+offer+support+for+families.Creating+opportunities+for+Recovery%21BOOSTER.COM5+Comments19+SharesSeen+by+233+Amy+Tompkins+Albanese%2C+Dina+DiDario+and+Audrey+PorterLikeLikeLoveHahaWowSadAngryCommentShareNews+FeedRECENT+ACTIVITYKatrin+O%27Leary+commented+on+this+post.Audrey+PorterYesterday+at+7%3A46pmEngaging+Campuses+to+Help+Americans+',
 'HTTP_USER_AGENT': 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X)
 AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G36
 [FBAN/FBIOS;FBAV/64.0.0.43.138;FBBV/38842789;FBRV/0;FBDV/iPhone6,1;FBMD/iPhone;FBSN/iPhone
 OS;FBSV/9.3.5;FBSS/2;FBCR/Sprint;FBID/phone;FBLC/en_US;FBOP/5]',
 'HTTP_X_FORWARDED_FOR': '66.87.148.22, 108.162.210.208, 172.31.16.24',
 'HTTP_X_FORWARDED_PORT': '443',
 'HTTP_X_FORWARDED_PROTO': 'https',
 'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest',
 'PATH_INFO': u'/questions/5848/vote/',
 'QUERY_STRING': '',
 'RAW_URI': '/questions/5848/vote/',
 'REMOTE_ADDR': '127.0.0.1',
 'REMOTE_PORT': '35920',
 'REQUEST_METHOD': 'POST',
 'SCRIPT_NAME': u'',
 'SERVER_NAME': '127.0.0.1',
 'SERVER_PORT': '8003',
 'SERVER_PROTOCOL': 'HTTP/1.0',
 'SERVER_SOFTWARE': 'gunicorn/19.4.3',
 'gunicorn.socket': <socket._socketobject object at 0x7f93f3f1b520>,
 'wsgi.errors': <gunicorn.http.wsgi.WSGIErrorsWrapper object at
 0x7f93f3ea0710>,
 'wsgi.file_wrapper': <class 'gunicorn.http.wsgi.FileWrapper'>,
 'wsgi.input': <newrelic.api.web_transaction._WSGIInputWrapper object at
 0x7f93f3e667d0>,
 'wsgi.multiprocess': True,
 'wsgi.multithread': False,
 'wsgi.run_once': False,
 'wsgi.url_scheme': 'https',
 'wsgi.version': (1, 0)}>
```
