### PR TITLE
Hide merge flags for ideas that have already been removed from site in another way

### DIFF
--- a/opendebates/moderator_views.py
+++ b/opendebates/moderator_views.py
@@ -135,8 +135,11 @@ def home(request):
                                             .filter(num_flags__gt=0) \
                                             .order_by('-num_flags')
 
-    # all merge flags which have not yet been reviewed
-    merge_flags = Flag.objects.exclude(duplicate_of=None).exclude(reviewed=True)
+    # all merge flags which have not yet been reviewed and whose targets have not been removed
+    merge_flags = Flag.objects.exclude(duplicate_of=None) \
+                              .exclude(reviewed=True) \
+                              .exclude(duplicate_of__moderated_removal=True) \
+                              .exclude(to_remove__moderated_removal=True)
 
     return {
         'flagged_for_removal': flagged_for_removal,

--- a/opendebates/tests/test_moderation.py
+++ b/opendebates/tests/test_moderation.py
@@ -434,6 +434,22 @@ class ModerationHomeTest(TestCase):
         self.assertNotIn(already_reviewed_flag, qs)
         self.assertEqual(set(merge_flags), set(qs))
 
+        # If either end of the merge flag  has been unmoderated separately,
+        # the merge flag should not appear on the page - we don't allow
+        # removed submissions to be merged or to receive merges
+
+        merge_flags[0].to_remove.approved = False
+        merge_flags[0].to_remove.moderated_removal = True
+        merge_flags[0].to_remove.save()
+        rsp = self.client.get(self.url)
+        self.assertNotIn(merge_flags[0], rsp.context['merge_flags'])
+
+        merge_flags[1].duplicate_of.approved = False
+        merge_flags[1].duplicate_of.moderated_removal = True
+        merge_flags[1].duplicate_of.save()
+        rsp = self.client.get(self.url)
+        self.assertNotIn(merge_flags[1], rsp.context['merge_flags'])
+
 
 class RemovalFlagTest(TestCase):
 


### PR DESCRIPTION
If an idea has been flagged for merge, but either the flagged idea or its destination has been unmoderated -- the merge flag just gets stuck in the queue and cannot be reviewed or removed (since we correctly error on /moderation/preview/ when either to_remove or duplicate_of is not approved)

This change should un-stuck those flags by hiding them altogether from the moderation interface, without touching the flags so that they can reappear if the underlying submissions somehow become approved again.
