### PR TITLE
Let admins set up a progression of site modes in time

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -86,12 +86,13 @@ class TopSubmissionCategoryAdmin(ModelAdmin):
 
 @register(models.SiteMode)
 class SiteModeAdmin(ModelAdmin):
-    list_display = ['debate_time', 'show_question_votes', 'show_total_votes',
-                    'allow_sorting_by_votes']
+    list_display = ['effective_after', 'debate_time', 'show_question_votes',
+                    'show_total_votes', 'allow_sorting_by_votes']
     _fields = [f.name for f in models.SiteMode._meta.get_fields() if f.name != 'id']
     fieldsets = [
         ('General Settings', {
-            'fields': ['show_question_votes', 'show_total_votes',
+            'fields': ['effective_after',
+                       'show_question_votes', 'show_total_votes',
                        'allow_sorting_by_votes',
                        'allow_voting_and_submitting_questions',
                        'inline_css']

--- a/opendebates/migrations/0031_sitemode_effective_after.py
+++ b/opendebates/migrations/0031_sitemode_effective_after.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0030_auto_20160927_1242'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='effective_after',
+            field=models.DateTimeField(default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=utc), unique=True),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -7,6 +7,7 @@ from djorm_pgfulltext.models import SearchManager
 from djorm_pgfulltext.fields import VectorField
 from urllib import quote_plus
 from django.utils.http import urlquote
+from django.utils.timezone import make_aware
 from django.utils.translation import ugettext_lazy as _
 from caching.base import CachingManager, CachingMixin
 from localflavor.us.models import PhoneNumberField
@@ -45,6 +46,11 @@ class FlatPageMetadataOverride(models.Model):
 
 
 class SiteMode(CachingMixin, models.Model):
+
+    effective_after = models.DateTimeField(
+        default=make_aware(datetime.datetime.fromtimestamp(0)),
+        unique=True)
+
     show_question_votes = models.BooleanField(default=True, blank=True)
     show_total_votes = models.BooleanField(default=True, blank=True)
     allow_sorting_by_votes = models.BooleanField(default=True, blank=True)

--- a/opendebates/tests/test_site_mode.py
+++ b/opendebates/tests/test_site_mode.py
@@ -1,6 +1,62 @@
+from datetime import timedelta
 from django.test import TestCase
+from django.utils.timezone import now
+from freezegun import freeze_time
 
 from opendebates.models import SiteMode
+from opendebates import utils
+
+
+class EffectiveAfterTest(TestCase):
+    def setUp(self):
+        self.mode, _ = SiteMode.objects.get_or_create()
+        self.start_time = now()
+        SiteMode(announcement_headline='Tune in tonight!',
+                 effective_after=self.start_time + timedelta(minutes=30)).save()
+        SiteMode(announcement_headline='Watch - happening now!',
+                 allow_voting_and_submitting_questions=False,
+                 effective_after=self.start_time + timedelta(minutes=60)).save()
+        SiteMode(announcement_headline='Thanks for participating!',
+                 allow_voting_and_submitting_questions=False,
+                 show_total_votes=False,
+                 effective_after=self.start_time + timedelta(minutes=90)).save()
+
+    def test_default_active_sitemode(self):
+        self.assertEqual(utils.get_site_mode(), self.mode)
+
+    def test_no_sitemode_effective_yet_creates_one(self):
+        self.mode.delete()
+        with freeze_time(self.start_time):
+            self.assertEqual(SiteMode.objects.all().count(), 3)
+            self.assertEqual(utils.get_site_mode().announcement_headline, None)
+            self.assertEqual(SiteMode.objects.all().count(), 4)
+
+    def test_effective_after(self):
+        with freeze_time(self.start_time + timedelta(minutes=31)):
+            self.assertEqual(utils.get_site_mode().announcement_headline,
+                             'Tune in tonight!')
+
+    def test_active_sitemode_is_latest_past_effective_after(self):
+        with freeze_time(self.start_time + timedelta(minutes=61)):
+            self.assertEqual(utils.get_site_mode().announcement_headline,
+                             'Watch - happening now!')
+
+    def test_sitemode_progression_takes_effect_automatically(self):
+        url = '/'
+        with freeze_time(self.start_time + timedelta(minutes=1)):
+            rsp = self.client.get(url)
+            self.assertContains(rsp, 'Submit a Question')
+            self.assertContains(rsp, '<span class="number">')
+
+        with freeze_time(self.start_time + timedelta(minutes=61)):
+            rsp = self.client.get(url)
+            self.assertNotContains(rsp, 'Submit a Question')
+            self.assertContains(rsp, '<span class="number">')
+
+        with freeze_time(self.start_time + timedelta(minutes=91)):
+            rsp = self.client.get(url)
+            self.assertNotContains(rsp, 'Submit a Question')
+            self.assertNotContains(rsp, '<span class="number">')
 
 
 class AnnouncementTest(TestCase):

--- a/opendebates/utils.py
+++ b/opendebates/utils.py
@@ -3,6 +3,7 @@ import random
 
 from django.conf import settings
 from django.core.cache import cache
+from django.utils.timezone import now
 
 from .models import Vote, Voter, NUMBER_OF_VOTES_CACHE_ENTRY, SiteMode
 from .router import readwrite_db
@@ -136,11 +137,14 @@ def sort_list(citations_only, sort, ideas):
 
 
 def get_site_mode():
+    current_time = now()
     try:
-        return SiteMode.objects.get()
-    except SiteMode.DoesNotExist:
+        return SiteMode.objects.filter(
+            effective_after__lt=current_time).order_by("-effective_after")[0]
+    except IndexError:
         with readwrite_db():
-            return SiteMode.objects.get_or_create()[0]
+            return SiteMode.objects.get_or_create(
+                effective_after__lt=current_time)[0]
 
 
 def allow_sorting_by_votes():

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,3 +12,5 @@ factory-boy==2.6.0
 fabulaws==0.3.0a29
 
 mock==1.3.0
+python-dateutil==2.5.3
+freezegun==0.3.7


### PR DESCRIPTION
Proof of concept -- definitely no urgency here.  But curious what you all think of this idea.  It should play well with #197 and #202 too.

Proposal:

Each site mode has a unique "effective after" datetime set by admins.  The currently active site mode is found by looking at all of the sitemodes that have become effective (i.e. their "effective after" date is in the past) and then finding the latest of those sitemodes (i.e. the one that became "effective" most recently).

This allows admins to set up a series of site modes that they know they will need
at the very beginning, e.g.:
- A pre-launch sitemode that disallows voting and submissions
- An initial sitemode for when the site launches
- A sitemode for the day before the debate, with a "Remember to tune in tomorrow"
  announcement
- A sitemode for the day of the debate, with a "VOTING ENDS TONIGHT" announcement
- A sitemode for 30 minutes before the debate, with voting no longer allowed
- A sitemode for the morning after the debate, with a "Thanks for participating" announcement

They can then just walk away knowing that the site will progress through these modes
without any additional intervention.  And in the meantime, for smaller ad-hoc changes
(e.g. updating the banner text, adding some css customizations, changing the social shares)
admins can still edit the currently active site mode at any time and they will still
take effect immediately.
