### PR TITLE
Use an alternate form of management.call_command

### DIFF
--- a/opendebates/tasks.py
+++ b/opendebates/tasks.py
@@ -102,5 +102,5 @@ def update_trending_scores():
 def backup_database():
     """ Backup the database using django-dbbackup """
     logger.info("start database_backup")
-    management.call_command('dbbackup', '--compress')
+    management.call_command('dbbackup', compress=True)
     logger.info("end database_backup")


### PR DESCRIPTION
I think because django-dbbackup wrote their management command class
to only take kwargs?  Anyways, this is manually verified to work in
the Django shell.
