### PR TITLE
Add a subtract_invalid_votes field to SiteMode and adjust counts accordingly

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -99,7 +99,7 @@ class SiteModeAdmin(ModelAdmin):
             'fields': ['show_question_votes', 'show_total_votes',
                        'allow_sorting_by_votes',
                        'allow_voting_and_submitting_questions',
-                       'inline_css']
+                       'subtract_invalid_votes', 'inline_css']
         }),
         ('Debate Details', {
             'fields': [f for f in _fields if 'debate_' in f],

--- a/opendebates/migrations/0039_sitemode_subtract_invalid_votes_field.py
+++ b/opendebates/migrations/0039_sitemode_subtract_invalid_votes_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0038_remove_fraud_fields_nullability3'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitemode',
+            name='subtract_invalid_votes',
+            field=models.PositiveIntegerField(default=0, help_text=b'Enter in the number of known invalid votes (that have not been explicitly marked as such directly) to remove them from the site-wide total.'),
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -47,6 +47,13 @@ class FlatPageMetadataOverride(models.Model):
 class SiteMode(CachingMixin, models.Model):
     show_question_votes = models.BooleanField(default=True, blank=True)
     show_total_votes = models.BooleanField(default=True, blank=True)
+    subtract_invalid_votes = models.PositiveIntegerField(
+        default=0,
+        help_text=(
+            "Enter in the number of known invalid votes (that have not been explicitly"
+            " marked as such directly) to remove them from the site-wide total."
+        )
+    )
     allow_sorting_by_votes = models.BooleanField(default=True, blank=True)
     allow_voting_and_submitting_questions = models.BooleanField(default=True, blank=True)
     debate_time = models.DateTimeField(

--- a/opendebates/tasks.py
+++ b/opendebates/tasks.py
@@ -10,6 +10,7 @@ from django.db.models import F
 from opendebates.models import Vote, Submission, RECENT_EVENTS_CACHE_ENTRY, \
     NUMBER_OF_VOTES_CACHE_ENTRY
 from opendebates.router import set_thread_readonly_db, set_thread_readwrite_db
+from opendebates.utils import get_site_mode
 
 
 sql2 = """
@@ -70,8 +71,10 @@ def update_recent_events():
 
         cache.set(RECENT_EVENTS_CACHE_ENTRY, entries, 24*3600)
 
+        sitemode = get_site_mode()
         number_of_votes = Vote.objects.count()
-        cache.set(NUMBER_OF_VOTES_CACHE_ENTRY, number_of_votes, 24*3600)
+        invalid = sitemode.subtract_invalid_votes
+        cache.set(NUMBER_OF_VOTES_CACHE_ENTRY, number_of_votes - invalid, 24*3600)
 
         logger.debug("There are %d entries" % len(entries))
         logger.debug("There are %d votes" % number_of_votes)


### PR DESCRIPTION
If the moderation team identifies a bunch of fraudulent votes by hand,
as they did with the presidential site, at least provide the
capability of adjusting the site-wide count to match.
