### PR TITLE
Add the debate id to the cache key for various template snippets

### DIFF
--- a/opendebates/migrations/0041_auto_20170331_1023.py
+++ b/opendebates/migrations/0041_auto_20170331_1023.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opendebates', '0040_auto_20170330_1101'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='topsubmissioncategory',
+            options={'verbose_name_plural': 'top submission categories'},
+        ),
+    ]

--- a/opendebates/models.py
+++ b/opendebates/models.py
@@ -389,6 +389,7 @@ class TopSubmissionCategory(models.Model):
     caption = models.CharField(max_length=255, blank=True)
 
     class Meta:
+        verbose_name_plural = _("top submission categories")
         unique_together = [('debate', 'slug')]
 
     def __unicode__(self):

--- a/opendebates/templates/opendebates/changelog.html
+++ b/opendebates/templates/opendebates/changelog.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="row breadcrumbs">
-  <a href="/">{% blocktrans %}Home{% endblocktrans %}</a>
+  <a href="{% url 'list_ideas' %}">{% blocktrans %}Home{% endblocktrans %}</a>
   <span class="hidden-xs">&#8594;</span>
   <a class="hidden-xs" href="">{% blocktrans %}Changelog{% endblocktrans %}</a>
 </div>

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -25,7 +25,7 @@
   <div class="vcenter {% if not category %}active-category-nav{% endif %}">
     <a href="/">{% blocktrans %}All Issue Areas{% endblocktrans %}</a>
   </div>
-  {% cache 279 option_categories category.id %}
+  {% cache 279 option_categories DEBATE.id category.id %}
     {% for option in SUBMISSION_CATEGORIES %}
       {% if option.name != "Hidden" and option.name != "Uncategorized" and option.name != "Other" %}
         <div class="vcenter {% if category and category.id == option.id %}active-category-nav{% endif %}">
@@ -39,7 +39,7 @@
   {% trans "Issue areas" %}<br/>
   <select id="category-select-picker" class="selectpicker" onchange="javascript:window.location=$(this).val() + window.location.search;">
     <option value="/">All</option>
-    {% cache 299 cat_options category.id %}
+    {% cache 299 cat_options DEBATE.id category.id %}
       {% for option in SUBMISSION_CATEGORIES %}
         {% if option.name != "Hidden" and option.name != "Uncategorized" and option.name != "Other" %}
           <option {% if category and category.id == option.id %}selected{% endif %} value="{% url 'list_category' option.id %}">{{ option.name }}</option>
@@ -52,7 +52,7 @@
 {% endblock %}
 
 {% block primary_content %}
-  {% cache 30 list_ideas_content sort url_name search_term category.id %}
+  {% cache 30 list_ideas_content sort url_name search_term DEBATE.id category.id %}
     <div class="sort-column">
       <form action="{{ url_name }}" method="GET" class="form-inline">
 
@@ -101,14 +101,14 @@
         </select>
         <div class="display-count">
 
-            Displaying <strong>{% cache 57 idea_count search_term category.id %}{{ ideas.count }}{% endcache %} Questions</strong>
+            Displaying <strong>{% cache 57 idea_count search_term DEBATE.id category.id %}{{ ideas.count }}{% endcache %} Questions</strong>
         </div>
       </form>
     </div>
     {% endcache %}
     
   {% show_current_number as page_number %}
-  {% cache 30 idea_list search_term category.id sort page_number request.GET.source %}
+  {% cache 30 idea_list search_term DEBATE.id category.id sort page_number request.GET.source %}
 
   <hr class="before-idea-list visible-xs" />
   <div class="row idea-list">

--- a/opendebates/templates/opendebates/list_ideas.html
+++ b/opendebates/templates/opendebates/list_ideas.html
@@ -23,7 +23,7 @@
 
 <div class="row white category-only hidden-xs text-center">
   <div class="vcenter {% if not category %}active-category-nav{% endif %}">
-    <a href="/">{% blocktrans %}All Issue Areas{% endblocktrans %}</a>
+    <a href="{% url 'list_ideas' %}">{% blocktrans %}All Issue Areas{% endblocktrans %}</a>
   </div>
   {% cache 279 option_categories DEBATE.id category.id %}
     {% for option in SUBMISSION_CATEGORIES %}
@@ -38,7 +38,7 @@
 <label id="category-select-picker-ctn" for="category-select-picker">
   {% trans "Issue areas" %}<br/>
   <select id="category-select-picker" class="selectpicker" onchange="javascript:window.location=$(this).val() + window.location.search;">
-    <option value="/">All</option>
+    <option value="{% url 'list_ideas' %}">All</option>
     {% cache 299 cat_options DEBATE.id category.id %}
       {% for option in SUBMISSION_CATEGORIES %}
         {% if option.name != "Hidden" and option.name != "Uncategorized" and option.name != "Other" %}

--- a/opendebates/templates/opendebates/snippets/add_question.html
+++ b/opendebates/templates/opendebates/snippets/add_question.html
@@ -30,7 +30,7 @@
           <div class="controls">
             <select name="category" class="selectpicker">
               <option>--</option>
-              {% cache 331 add_question_iter_category category %}
+              {% cache 331 add_question_iter_category DEBATE.id category.id %}
                 {% for iter_category in SUBMISSION_CATEGORIES %}
                 <option {% if iter_category.id|slugify == form.data.category or iter_category.id == category.id %}selected{% endif %}
                         value="{{ iter_category.id }}">{{ iter_category.name }}</option>

--- a/opendebates/templates/opendebates/vote.html
+++ b/opendebates/templates/opendebates/vote.html
@@ -22,7 +22,7 @@
 
 {% block content %}
 <div class="row breadcrumbs">
-  <a href="/">{% blocktrans %}Home{% endblocktrans %}</a>
+  <a href="{% url 'list_ideas' %}">{% blocktrans %}Home{% endblocktrans %}</a>
   <span>&#8594;</span>
   <a href="{% url 'list_category' idea.category.id %}">{{ idea.category }}</a>
   <span class="hidden-xs">&#8594;</span>
@@ -43,9 +43,9 @@
     </h3>
     <p class="small removal-notice-text">
       Our team of moderators has determined that this question violates our
-      <a href="/participation/">participation guidelines</a>.  If you have any
+      <a href="/{{ DEBATE.prefix }}/participation/">participation guidelines</a>.  If you have any
       questions or concerns, or believe we should reconsider the moderators'
-      review, please <a href="/contact/">contact us</a>.
+      review, please <a href="/{{ DEBATE.prefix }}/contact/">contact us</a>.
     </p>
     {% endif %}
   </div>


### PR DESCRIPTION
so that when the question category is None (which happens when you are
not browsing under a particular category on the site), the item will
still be cached in a way that is debate-specific.