### PR TITLE
Admin display filter debate

### DIFF
--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -93,9 +93,19 @@ class CandidateAdmin(ModelAdmin):
 
 @register(models.Flag)
 class FlagAdmin(ModelAdmin):
-    list_display = [f.name for f in models.Flag._meta.fields]
+    list_display = ('id', 'prefix', 'to_remove', 'duplicate_of', 'voter', 'reviewed', 'note')
+    list_filter = ('to_remove__category__debate__prefix',)
     actions = [admin_list_export]
     raw_id_fields = ['to_remove', 'duplicate_of', 'voter']
+
+    def prefix(self, obj):
+        return format_html(
+            '<a href="{}">{}</a>'.format(
+                reverse('admin:opendebates_debate_change',
+                        args=(obj.to_remove.category.debate.pk,)),
+                obj.to_remove.category.debate.prefix)
+        )
+    prefix.short_description = "Debate prefix"
 
 
 @register(models.TopSubmissionCategory)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -89,9 +89,17 @@ class VoterAdmin(ModelAdmin):
 
 @register(models.Vote)
 class VoteAdmin(ModelAdmin):
-    list_display = [f.name for f in models.Vote._meta.fields]
+    list_display = ['id', 'prefix'] + [f.name for f in models.Vote._meta.fields
+                                       if f.name != 'id']
+    list_filter = ('submission__category__debate__prefix',)
+    list_select_related = ('submission__category__debate',)
+
     actions = [admin_list_export]
     raw_id_fields = ['submission', 'voter', 'original_merged_submission']
+
+    def prefix(self, obj):
+        return debate_link(obj.submission.category.debate)
+    prefix.short_description = "Debate prefix"
 
 
 @register(models.Candidate)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -1,7 +1,9 @@
 import itertools
 
 from django.contrib.admin import ModelAdmin, register
+from django.core.urlresolvers import reverse
 from django.shortcuts import render
+from django.utils.html import format_html
 from django.utils.timezone import now
 from djangohelpers.export_action import admin_list_export
 
@@ -11,8 +13,21 @@ from opendebates_emails.models import send_email
 
 @register(models.Category)
 class CategoryAdmin(ModelAdmin):
-    list_display = [f.name for f in models.Category._meta.fields]
-    actions = [admin_list_export]
+    list_display = ('name', 'prefix', 'site')
+    list_filter = ('debate__prefix',)
+    actions = (admin_list_export,)
+
+    def prefix(self, obj):
+        return format_html(
+            '<a href="{}">{}</a>'.format(
+                reverse('admin:opendebates_debate_change', args=(obj.debate.pk,)),
+                obj.debate.prefix)
+        )
+    prefix.short_description = "Debate prefix"
+
+    def site(self, obj):
+        return obj.debate.site
+    site.short_description = "Debate site"
 
 
 @register(models.Submission)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -90,8 +90,8 @@ class TopSubmissionCategoryAdmin(ModelAdmin):
 
 @register(models.Debate)
 class DebateAdmin(ModelAdmin):
-    list_display = ['site', 'debate_time', 'previous_debate_time', 'show_question_votes',
-                    'show_total_votes', 'allow_sorting_by_votes']
+    list_display = ['prefix', 'site', 'debate_time', 'previous_debate_time',
+                    'show_question_votes', 'show_total_votes', 'allow_sorting_by_votes']
     actions = ['reset_current_votes']
     _fields = [f.name for f in models.Debate._meta.get_fields() if f.name != 'id']
     fieldsets = [

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -21,17 +21,15 @@ def debate_link(debate):
 
 @register(models.Category)
 class CategoryAdmin(ModelAdmin):
-    list_display = ('name', 'prefix', 'site')
+    list_display = ('name', 'prefix')
     list_filter = ('debate__prefix',)
+    list_select_related = ('debate',)
+
     actions = (admin_list_export,)
 
     def prefix(self, obj):
         return debate_link(obj.debate)
     prefix.short_description = "Debate prefix"
-
-    def site(self, obj):
-        return obj.debate.site
-    site.short_description = "Debate site"
 
 
 @register(models.Submission)
@@ -39,6 +37,8 @@ class SubmissionAdmin(ModelAdmin):
     list_display = ['id', 'prefix'] + [f.name for f in models.Submission._meta.fields
                                        if f.name != 'id']
     list_filter = ('approved', 'category__debate__prefix')
+    list_select_related = ('category__debate',)
+
     search_fields = ('idea',)
     actions = [admin_list_export, 'remove_submissions']
     raw_id_fields = ['voter', 'duplicate_of']
@@ -104,6 +104,8 @@ class CandidateAdmin(ModelAdmin):
 class FlagAdmin(ModelAdmin):
     list_display = ('id', 'prefix', 'to_remove', 'duplicate_of', 'voter', 'reviewed', 'note')
     list_filter = ('to_remove__category__debate__prefix',)
+    list_select_related = ('to_remove__category__debate',)
+
     actions = [admin_list_export]
     raw_id_fields = ['to_remove', 'duplicate_of', 'voter']
 
@@ -116,6 +118,7 @@ class FlagAdmin(ModelAdmin):
 class TopSubmissionCategoryAdmin(ModelAdmin):
     list_display = ('slug', 'prefix', 'title')
     list_filter = ('debate__prefix',)
+    list_select_related = ('debate',)
 
     def prefix(self, obj):
         return debate_link(obj.debate)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -109,7 +109,12 @@ class FlagAdmin(ModelAdmin):
 
 @register(models.TopSubmissionCategory)
 class TopSubmissionCategoryAdmin(ModelAdmin):
-    list_display = ['debate', 'slug', 'title']
+    list_display = ('slug', 'prefix', 'title')
+    list_filter = ('debate__prefix',)
+
+    def prefix(self, obj):
+        return debate_link(obj.debate)
+    prefix.short_description = "Debate prefix"
 
 
 @register(models.Debate)

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -36,11 +36,16 @@ class CategoryAdmin(ModelAdmin):
 
 @register(models.Submission)
 class SubmissionAdmin(ModelAdmin):
-    list_display = [f.name for f in models.Submission._meta.fields]
+    list_display = ['id', 'prefix'] + [f.name for f in models.Submission._meta.fields
+                                       if f.name != 'id']
     list_filter = ('approved', 'category__debate__prefix')
     search_fields = ('idea',)
     actions = [admin_list_export, 'remove_submissions']
     raw_id_fields = ['voter', 'duplicate_of']
+
+    def prefix(self, obj):
+        return debate_link(obj.category.debate)
+    prefix.short_description = "Debate prefix"
 
     def remove_submissions(self, request, queryset):
         "Custom action to mark submissions 'unapproved' and to notify users by email."

--- a/opendebates/admin.py
+++ b/opendebates/admin.py
@@ -11,6 +11,14 @@ from . import models
 from opendebates_emails.models import send_email
 
 
+def debate_link(debate):
+    return format_html(
+        '<a href="{}">{}</a>'.format(
+            reverse('admin:opendebates_debate_change', args=(debate.pk,)),
+            debate.prefix)
+    )
+
+
 @register(models.Category)
 class CategoryAdmin(ModelAdmin):
     list_display = ('name', 'prefix', 'site')
@@ -18,11 +26,7 @@ class CategoryAdmin(ModelAdmin):
     actions = (admin_list_export,)
 
     def prefix(self, obj):
-        return format_html(
-            '<a href="{}">{}</a>'.format(
-                reverse('admin:opendebates_debate_change', args=(obj.debate.pk,)),
-                obj.debate.prefix)
-        )
+        return debate_link(obj.debate)
     prefix.short_description = "Debate prefix"
 
     def site(self, obj):
@@ -33,8 +37,8 @@ class CategoryAdmin(ModelAdmin):
 @register(models.Submission)
 class SubmissionAdmin(ModelAdmin):
     list_display = [f.name for f in models.Submission._meta.fields]
-    list_filter = ('approved', )
-    search_fields = ('idea', )
+    list_filter = ('approved', 'category__debate__prefix')
+    search_fields = ('idea',)
     actions = [admin_list_export, 'remove_submissions']
     raw_id_fields = ['voter', 'duplicate_of']
 
@@ -99,12 +103,7 @@ class FlagAdmin(ModelAdmin):
     raw_id_fields = ['to_remove', 'duplicate_of', 'voter']
 
     def prefix(self, obj):
-        return format_html(
-            '<a href="{}">{}</a>'.format(
-                reverse('admin:opendebates_debate_change',
-                        args=(obj.to_remove.category.debate.pk,)),
-                obj.to_remove.category.debate.prefix)
-        )
+        return debate_link(obj.to_remove.category.debate)
     prefix.short_description = "Debate prefix"
 
 


### PR DESCRIPTION
This adds a linking column showing the prefix of the debate each item is associated with for the models that are debate-specific (Category, Submission, Vote, Flag, TopSubmissionCategory), and adds the ability to filter by debate to those admin lists.  Additionally, it shows the url prefix as a column for the Debate admin list view.

Left out of this change are: Voter (which is site-wide, not debate-specific), FlatPageMetadataOverride (which is one-to-one with Django's FlatPage model), and Candidate (which is, as far as I can tell, a model which is no longer used).