### PR TITLE
[DIS-1120] Template Variable Can Be Parsed On Front-End

### DIFF
--- a/opendebates/templates/base.html
+++ b/opendebates/templates/base.html
@@ -181,7 +181,7 @@
   {% endif %}
 </script>
 <script id="my-votes-cast" type="application/json">
-  {{ VOTES_CAST }}
+  {{ VOTES_CAST|safe }}
 </script>
 
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1120

Our front-end JavaScript (specifically, [`opendebates/static/js/base/helpers.js`](https://github.com/caktus/django-opendebates/blob/develop/opendebates/static/js/base/helpers.js#L156-L165)) looks for an element in the template with the `"my-votes-cast"` id, and tries to parse its contents into JSON. This element exists in our base template ([`opendebates/templates/base.html`](https://github.com/caktus/django-opendebates/blob/develop/opendebates/templates/base.html#L183-L185)), and is simply a `<script>` that renders the `VOTES_CAST` template variable: 
```
<script id="my-votes-cast" type="application/json">
  {{ VOTES_CAST }}
</script>
```

Though the backend ([`opendebates/context_processors.py`](https://github.com/caktus/django-opendebates/blob/develop/opendebates/context_processors.py#L27)) tried to mark the variable as not needing HTML escaping, it was still being shown in the template as invalid JSON, like `{&quot;submissions&quot;: [3, 1]}`.

The solution is to use the `safe` Django template filter in our base template, so that things like `"{"` within the VOTES_CAST template variable do not get turned into something like `&quot;`, and instead the JavaScript can parse the contents of the `VOTES_CAST` template variable.