### PR TITLE
give celery beat and celery workers distinct labels (fix 502 error)

### DIFF
--- a/kubernetes/beat.yaml.j2
+++ b/kubernetes/beat.yaml.j2
@@ -13,20 +13,20 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "opendebates-beat"
+  name: "celery-beat"
   namespace: "{{ NAMESPACE }}"
 spec:
   selector:
     matchLabels:
-      app: "opendebates"
+      app: "celery-beat"
   replicas: 1
   template:
     metadata:
       labels:
-        app: "opendebates"
+        app: "celery-beat"
     spec:
       containers:
-      - name: "opendebates-beat"
+      - name: "celery-beat"
         image: "{{ OPENDEBATES_IMAGE }}:{{ OPENDEBATES_VERSION }}"
         imagePullPolicy: Always
         args: ["celery", "--app=opendebates", "beat", "--workdir=/code", "--loglevel=info", "--pidfile=/data/beat.pid", "--schedule=/data/schedulefile.db"]

--- a/kubernetes/workers.yaml.j2
+++ b/kubernetes/workers.yaml.j2
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "opendebates-workers"
+  name: "celery-worker"
   namespace: "{{ NAMESPACE }}"
 spec:
   selector:
     matchLabels:
-      app: "opendebates"
+      app: "celery-worker"
   replicas: {{ OPENDEBATES_WORKERS }}
   template:
     metadata:
       labels:
-        app: "opendebates"
+        app: "celery-worker"
     spec:
       containers:
-      - name: "opendebates-workers"
+      - name: "celery-worker"
         image: "{{ OPENDEBATES_IMAGE }}:{{ OPENDEBATES_VERSION }}"
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
If the old deployments have already been pushed out to other namespaces, you'll need to run this to clean out the old pods/deployments:

```
kubectl -n <namespace> delete deployment opendebates-workers
kubectl -n <namespace> delete deployment opendebates-beat
```

I've already done this for `opendebates-testing`. It shouldn't matter whether the old deployments are deleted first and then the changes are deployed, or vice versa.