### PR TITLE
change imagePullPolicy to IfNotPresent

### DIFF
--- a/kubernetes/beat.yaml.j2
+++ b/kubernetes/beat.yaml.j2
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: "celery-beat"
         image: "{{ OPENDEBATES_IMAGE }}:{{ OPENDEBATES_VERSION }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["celery", "--app=opendebates", "beat", "--workdir=/code", "--loglevel=info", "--pidfile=/data/beat.pid", "--schedule=/data/schedulefile.db"]
         env:
         - name: GET_HOSTS_FROM

--- a/kubernetes/memcached.yaml.j2
+++ b/kubernetes/memcached.yaml.j2
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: "memcached"
         image: "memcached:{{ MEMCACHED_VERSION }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         - name: GET_HOSTS_FROM
           value: dns

--- a/kubernetes/opendebates.yaml.j2
+++ b/kubernetes/opendebates.yaml.j2
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: "opendebates"
         image: "{{ OPENDEBATES_IMAGE }}:{{ OPENDEBATES_VERSION }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         - name: GET_HOSTS_FROM
           value: dns

--- a/kubernetes/redis.yaml.j2
+++ b/kubernetes/redis.yaml.j2
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: "redis"
         image: "redis:{{ REDIS_VERSION }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         - name: GET_HOSTS_FROM
           value: dns

--- a/kubernetes/workers.yaml.j2
+++ b/kubernetes/workers.yaml.j2
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: "celery-worker"
         image: "{{ OPENDEBATES_IMAGE }}:{{ OPENDEBATES_VERSION }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true
           runAsUser: {{ RUN_AS_USER_ID }}


### PR DESCRIPTION
Since we deploy specifically-tagged versions of everything, we don't have to re-pull the docker image for every single Pod.